### PR TITLE
Update URLs following iree-org move.

### DIFF
--- a/.github/workflows/regression_tests.yml
+++ b/.github/workflows/regression_tests.yml
@@ -10,7 +10,7 @@ jobs:
     name: "Regression test TF hub models"
     runs-on: ubuntu-18.04
     # Don't run this in everyone's forks.
-    if: github.repository == 'google/iree-samples'
+    if: github.repository == 'iree-org/iree-samples'
     steps:
       - name: Checking out repository
         uses: actions/checkout@v2
@@ -28,7 +28,7 @@ jobs:
 
       - name: Installed IREE & TF versions
         shell: bash
-        run: |          
+        run: |
           pip freeze | egrep 'iree|tensorflow'
 
       - name: Run Tests

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,7 +66,7 @@ for them (e.g. because they don't have write access).
 ## Peculiarities
 
 Our documentation on
-[repository management](https://github.com/google/iree/blob/main/docs/developers/developing_iree/repository_management.md)
+[repository management](https://github.com/iree-org/iree/blob/main/docs/developers/developing_iree/repository_management.md)
 has more information on some of the oddities in our repository setup and
 workflows. For the most part, these should be transparent to normal developer
 workflows.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # IREE Samples Repository
 
-This repository contains various samples and prototypes associated with the [IREE](https://github.com/google/iree) project.
+This repository contains various samples and prototypes associated with the [IREE](https://github.com/iree-org/iree) project.
 
-Contact the [IREE Team](https://github.com/google/iree#communication-channels) for questions about this repository.
+Contact the [IREE Team](https://github.com/iree-org/iree#communication-channels) for questions about this repository.
 
 ## Setting up a venv
 

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -27,7 +27,7 @@ include(FetchContent)
 
 FetchContent_Declare(
   iree
-  GIT_REPOSITORY https://github.com/google/iree.git
+  GIT_REPOSITORY https://github.com/iree-org/iree.git
   GIT_TAG 7ca0f46fc38c7d5ccb7ee275db59ed7d992436ef # 2022-06-09
   GIT_SUBMODULES_RECURSE OFF
   GIT_SHALLOW ON

--- a/cpp/README.md
+++ b/cpp/README.md
@@ -2,7 +2,7 @@
 
 These C/C++ samples can be built using CMake. The samples depend on the main
 IREE project's C/C++ sources, including both the runtime and the compiler. See
-https://google.github.io/iree/building-from-source/getting-started/ for general
+https://iree-org.github.io/iree/building-from-source/getting-started/ for general
 information about build system installation and options, then from this project
 run
 

--- a/cpp/vision_inference/README.md
+++ b/cpp/vision_inference/README.md
@@ -5,4 +5,4 @@ model on an image using IREE's C API.
 
 A similar sample is implemented using a Python script and IREE's command line
 tools over in the primary iree repository at
-https://github.com/google/iree/tree/main/samples/vision_inference
+https://github.com/iree-org/iree/tree/main/samples/vision_inference

--- a/iree-jax/examples/high_level_mnist_export.py
+++ b/iree-jax/examples/high_level_mnist_export.py
@@ -68,7 +68,7 @@ def build_model(exp: exporter.ExportModule):
   # result of @jax.jit and that would be required.
   @export_pure_func
   def predict_target_class(params, inputs):
-    # TODO: An issue with argmax (https://github.com/google/iree/issues/7748).
+    # TODO: An issue with argmax (https://github.com/iree-org/iree/issues/7748).
     #predicted_class = jnp.argmax(predict(params, inputs), axis=1)
     #return predicted_class
     prediction = predict(params, inputs)

--- a/iree-jax/examples/staged_mnist_export.py
+++ b/iree-jax/examples/staged_mnist_export.py
@@ -91,7 +91,7 @@ def build_model():
 
     @kernel
     def _predict_target_class(params, inputs):
-      # TODO: An issue with argmax (https://github.com/google/iree/issues/7748).
+      # TODO: An issue with argmax (https://github.com/iree-org/iree/issues/7748).
       #predicted_class = jnp.argmax(predict(params, inputs), axis=1)
       #return predicted_class
       prediction = predict(params, inputs)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # IREE Python API
 # Use nightly releases at the GitHub releases page instead of PyPi
--f https://github.com/google/iree/releases
+-f https://github.com/iree-org/iree/releases
 iree-compiler
 iree-runtime
 iree-tools-tflite

--- a/scripts/integrate/bump_llvm.py
+++ b/scripts/integrate/bump_llvm.py
@@ -73,7 +73,7 @@ def main(args):
     # and you will find out.
     iree_utils.git_submodule_set_origin(
         "third_party/llvm-project",
-        url="https://github.com/google/iree-llvm-fork.git",
+        url="https://github.com/iree-org/iree-llvm-fork.git",
         branch="--default")
 
     # Remove the branch pin file, reverting us to pure upstream.
@@ -115,7 +115,7 @@ def parse_arguments(argv):
                         default="UPSTREAM_AUTOMATION")
     parser.add_argument("--upstream-repository",
                         help="Upstream repository URL",
-                        default="git@github.com:google/iree.git")
+                        default="git@github.com:iree-org/iree.git")
     parser.add_argument("--disable-setup-remote",
                         help="Disable remote setup",
                         action="store_true",

--- a/scripts/integrate/iree_modules.py
+++ b/scripts/integrate/iree_modules.py
@@ -25,9 +25,9 @@ MODULE_INFOS = {
         name="llvm-project",
         path="third_party/llvm-project",
         branch_pin_file="third_party/llvm-project.branch-pin",
-        default_repository_url="https://github.com/google/iree-llvm-fork.git",
-        fork_repository_push="git@github.com:google/iree-llvm-fork.git",
-        fork_repository_pull="https://github.com/google/iree-llvm-fork.git",
+        default_repository_url="https://github.com/iree-org/iree-llvm-fork.git",
+        fork_repository_push="git@github.com:iree-org/iree-llvm-fork.git",
+        fork_repository_pull="https://github.com/iree-org/iree-llvm-fork.git",
         branch_prefix="patched-llvm-project-",
     ),
     "mlir-hlo":
@@ -35,9 +35,9 @@ MODULE_INFOS = {
         name="mlir-hlo",
         path="third_party/mlir-hlo",
         branch_pin_file="third_party/mlir-hlo.branch-pin",
-        default_repository_url="https://github.com/google/iree-mhlo-fork.git",
-        fork_repository_push="git@github.com:google/iree-mhlo-fork.git",
-        fork_repository_pull="https://github.com/google/iree-mhlo-fork.git",
+        default_repository_url="https://github.com/iree-org/iree-mhlo-fork.git",
+        fork_repository_push="git@github.com:iree-org/iree-mhlo-fork.git",
+        fork_repository_pull="https://github.com/iree-org/iree-mhlo-fork.git",
         branch_prefix="patched-mlir-hlo-",
     )
 }


### PR DESCRIPTION
We moved from the [`google` organization](https://github.com/google) to the [`iree-org` organization](https://github.com/iree-org).