### PR TITLE
Disable failing nasnet regression test

### DIFF
--- a/tflitehub/nasnet_test.py
+++ b/tflitehub/nasnet_test.py
@@ -1,5 +1,6 @@
 # RUN: %PYTHON %s
 # REQUIRES: hugetest
+# XFAIL: *
 
 import absl.testing
 import numpy


### PR DESCRIPTION
nasnet_test.py is failing in nightly regression tests https://github.com/iree-org/iree-samples/runs/7422252950?check_suite_focus=true

Tracking in #62