### PR TITLE
Update call to create iree runtime in tests after API changes

### DIFF
--- a/tflitehub/test_util.py
+++ b/tflitehub/test_util.py
@@ -83,7 +83,7 @@ class TFLiteModelTest(testing.absltest.TestCase):
     with open(self.binary, 'rb') as f:
       config = iree_rt.Config(configs[absl.flags.FLAGS.config])
       self.iree_context = iree_rt.SystemContext(config=config)
-      vm_module = iree_rt.VmModule.from_flatbuffer(f.read())
+      vm_module = iree_rt.VmModule.from_flatbuffer(config.vm_instance, f.read())
       self.iree_context.add_vm_module(vm_module)
 
   def invoke_tflite(self, args):


### PR DESCRIPTION
Regression tests started failing after the API change in https://github.com/iree-org/iree/pull/10017, so update how the iree runtime is created 

Fixes #70 