### PR TITLE
Integrate IREE C/C++ source at c4624870 into samples.

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -12,7 +12,7 @@ cmake_minimum_required(VERSION 3.21...3.23)
 
 project(iree-samples C CXX)
 set(CMAKE_C_STANDARD 11)
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
 #-------------------------------------------------------------------------------
@@ -28,9 +28,9 @@ include(FetchContent)
 FetchContent_Declare(
   iree
   GIT_REPOSITORY https://github.com/iree-org/iree.git
-  GIT_TAG 7ca0f46fc38c7d5ccb7ee275db59ed7d992436ef # 2022-06-09
+  GIT_TAG c4624870a8de85224c3f02f4ea8e26837cd99e2f # 2022-08-12
   GIT_SUBMODULES_RECURSE OFF
-  GIT_SHALLOW ON
+  GIT_SHALLOW OFF
   GIT_PROGRESS ON
   USES_TERMINAL_DOWNLOAD ON
 )

--- a/cpp/vision_inference/CMakeLists.txt
+++ b/cpp/vision_inference/CMakeLists.txt
@@ -4,7 +4,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-if(NOT IREE_TARGET_BACKEND_DYLIB_LLVM_AOT OR
+if(NOT IREE_TARGET_BACKEND_LLVM_CPU OR
    NOT IREE_HAL_EXECUTABLE_LOADER_EMBEDDED_ELF)
   message(STATUS "Missing LLVM backend and/or embeddded elf loader, skipping vision_inference sample")
   return()
@@ -22,7 +22,7 @@ endif()
 set(_COMPILE_TOOL_EXECUTABLE $<TARGET_FILE:iree-compile>)
 set(_COMPILE_ARGS)
 list(APPEND _COMPILE_ARGS "--iree-input-type=mhlo")
-list(APPEND _COMPILE_ARGS "--iree-hal-target-backends=llvm")
+list(APPEND _COMPILE_ARGS "--iree-hal-target-backends=llvm-cpu")
 list(APPEND _COMPILE_ARGS "${IREE_SOURCE_DIR}/samples/models/mnist.mlir")
 list(APPEND _COMPILE_ARGS "-o")
 list(APPEND _COMPILE_ARGS "mnist.vmfb")

--- a/cpp/vision_inference/image_util.c
+++ b/cpp/vision_inference/image_util.c
@@ -140,13 +140,13 @@ iree_status_t iree_tools_utils_buffer_view_from_image(
         iree_hal_element_dense_byte_count(element_type);
     // SINT_8 and UINT_8 perform direct buffer wrap.
     result = iree_hal_buffer_view_allocate_buffer(
-        allocator, shape, shape_rank, element_type,
+        allocator, shape_rank, shape, element_type,
         IREE_HAL_ENCODING_TYPE_DENSE_ROW_MAJOR,
         (iree_hal_buffer_params_t){
             .type = IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL,
             .access = IREE_HAL_MEMORY_ACCESS_READ,
-            .usage =
-                IREE_HAL_BUFFER_USAGE_DISPATCH | IREE_HAL_BUFFER_USAGE_TRANSFER,
+            .usage = IREE_HAL_BUFFER_USAGE_DISPATCH_STORAGE |
+                     IREE_HAL_BUFFER_USAGE_TRANSFER,
         },
         iree_make_const_byte_span(pixel_data, element_byte * buffer_length),
         out_buffer_view);
@@ -207,11 +207,11 @@ iree_status_t iree_tools_utils_buffer_view_from_image_rescaled(
       .input_range_length = input_range_length,
   };
   iree_status_t status = iree_hal_buffer_view_generate_buffer(
-      allocator, shape, shape_rank, element_type, encoding_type,
+      allocator, shape_rank, shape, element_type, encoding_type,
       (iree_hal_buffer_params_t){
           .type = IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL |
                   IREE_HAL_MEMORY_TYPE_HOST_VISIBLE,
-          .usage = IREE_HAL_BUFFER_USAGE_DISPATCH |
+          .usage = IREE_HAL_BUFFER_USAGE_DISPATCH_STORAGE |
                    IREE_HAL_BUFFER_USAGE_TRANSFER |
                    IREE_HAL_BUFFER_USAGE_MAPPING,
       },

--- a/cpp/vulkan_gui/CMakeLists.txt
+++ b/cpp/vulkan_gui/CMakeLists.txt
@@ -86,7 +86,7 @@ target_link_libraries(${_NAME}
   #
   iree_runtime_runtime
   iree_base_internal_main
-  iree_hal_vulkan_registration_registration
+  iree_hal_drivers_vulkan_registration_registration
   iree_modules_hal_hal
   iree_samples_vulkan_gui_simple_mul_bytecode_module_c
   iree_vm_vm


### PR DESCRIPTION
https://github.com/iree-org/iree/commit/c4624870a8de85224c3f02f4ea8e26837cd99e2f

* Bump C++ standard from 14 to 17
* Use "llvm-cpu" target naming
* Use new hal/drivers/* paths for Vulkan driver
* Adapt to HAL and VM API changes