### PR TITLE
Disable failing regression tests

### DIFF
--- a/tflitehub/lightning_fp16_test.py
+++ b/tflitehub/lightning_fp16_test.py
@@ -1,4 +1,5 @@
 # RUN: %PYTHON %s
+# XFAIL: *
 
 import absl.testing
 import numpy

--- a/tflitehub/lightning_test.py
+++ b/tflitehub/lightning_test.py
@@ -1,4 +1,5 @@
 # RUN: %PYTHON %s
+# XFAIL: *
 
 import absl.testing
 import numpy

--- a/tflitehub/midas_test.py
+++ b/tflitehub/midas_test.py
@@ -1,4 +1,5 @@
 # RUN: %PYTHON %s
+# XFAIL: *
 
 import absl.testing
 import numpy

--- a/tflitehub/mirnet_test.py
+++ b/tflitehub/mirnet_test.py
@@ -1,5 +1,6 @@
 # RUN: %PYTHON %s
 # REQUIRES: hugetest
+# XFAIL: *
 
 import absl.testing
 import numpy

--- a/tflitehub/mobilenet_v1_uint8_test.py
+++ b/tflitehub/mobilenet_v1_uint8_test.py
@@ -1,4 +1,5 @@
 # RUN: %PYTHON %s
+# XFAIL: *
 
 import absl.testing
 import imagenet_test_data

--- a/tflitehub/mobilenet_v2_uint8_test.py
+++ b/tflitehub/mobilenet_v2_uint8_test.py
@@ -1,4 +1,5 @@
 # RUN: %PYTHON %s
+# XFAIL: *
 
 import absl.testing
 import imagenet_test_data

--- a/tflitehub/mobilenet_v3-large_uint8_test.py
+++ b/tflitehub/mobilenet_v3-large_uint8_test.py
@@ -1,4 +1,5 @@
 # RUN: %PYTHON %s
+# XFAIL: *
 
 import absl.testing
 import imagenet_test_data


### PR DESCRIPTION
Set tests to XFAIL until https://github.com/iree-org/iree-samples/issues/82 and https://github.com/iree-org/iree-samples/issues/83 are resolved:

lightning_fp16_test.py
lightning_test.py
midas_test.py
mirnet_test.py
mobilenet_v1_uint8_test.py
mobilenet_v2_uint8_test.py 
mobilenet_v3-large_uint8_test.py