### PR TITLE
Adds a standalone project to build customized IREE runtime libraries.

### DIFF
--- a/runtime-library/CMakeLists.txt
+++ b/runtime-library/CMakeLists.txt
@@ -1,0 +1,118 @@
+# Copyright 2023 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+cmake_minimum_required(VERSION 3.21...3.24)
+
+project(IREE_RUNTIME_LIBRARY)
+cmake_policy(SET CMP0069 NEW)
+
+set(IREE_ROOT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../iree" CACHE STRING "Main IREE source")
+
+# Enable LTO if supported.
+option(IREERT_ENABLE_LTO "Enable LTO (link time optimization) if supported" ON)
+include(CheckIPOSupported)
+check_ipo_supported(RESULT _ireert_lto_supported OUTPUT error)
+if(IREERT_ENABLE_LTO)
+  if(_ireert_lto_supported)
+    message(STATUS "Enabling LTO")
+    set(CMAKE_INTERPROCEDURAL_OPTIMIZATION ON)
+  else()
+    message(WARNING "LTO not supported by toolchain bit requested (ignored)")
+  endif()
+endif()
+
+# Optionally enabled shared library build mode. This is only supported for
+# development as it precludes important optimizations.
+option(BUILD_SHARED_LIBS "Build development shared runtime library" OFF)
+
+# When building a shared library, further customize:
+#   - Build with hidden visibility by default.
+#   - Unhide API exported functions.
+#   - Mark symbols for dllexport on Windows by default.
+if(BUILD_SHARED_LIBS)
+  message(STATUS "IREE runtime library with BUILD_SHARED_LIBS=ON is only supported for development!")
+  set(CMAKE_CXX_VISIBILITY_PRESET hidden)
+  add_compile_definitions("IREE_API_ENABLE_VISIBILITY")
+  add_compile_definitions("IREE_API_BUILDING_LIBRARY")
+endif()
+
+# Customize defaults.
+option(IREE_BUILD_COMPILER "Disable compiler for runtime-library build" OFF)
+option(IREE_BUILD_SAMPLES "Disable samples for runtime-library build" OFF)
+
+add_subdirectory("${IREE_ROOT_DIR}" "iree_core" EXCLUDE_FROM_ALL)
+
+#-------------------------------------------------------------------------------
+# Build the ireert library
+#-------------------------------------------------------------------------------
+
+# IREE exposes its transitive objects and deps on special target properties.
+set(_RUNTIME_ROOT_TARGET "iree::runtime::impl")
+set(_RUNTIME_OBJECTS "$<REMOVE_DUPLICATES:$<GENEX_EVAL:$<TARGET_PROPERTY:${_RUNTIME_ROOT_TARGET},INTERFACE_IREE_TRANSITIVE_OBJECTS>>>")
+set(_RUNTIME_LIBS "$<REMOVE_DUPLICATES:$<GENEX_EVAL:$<TARGET_PROPERTY:${_RUNTIME_ROOT_TARGET},INTERFACE_IREE_TRANSITIVE_OBJECT_LIBS>>>")
+ # For debugging, write out objects and deps to files.
+file(GENERATE OUTPUT "lib/ireert.objects.txt" CONTENT "${_RUNTIME_OBJECTS}\n")
+file(GENERATE OUTPUT "lib/ireert.libs.txt" CONTENT "${_RUNTIME_LIBS}\n")
+
+# Build the library (shared or static).
+add_library(ireert ${_RUNTIME_OBJECTS})
+target_include_directories(ireert INTERFACE "${CMAKE_CURRENT_BINARY_DIR}/include")
+target_link_libraries(ireert PUBLIC ${_RUNTIME_LIBS})
+set_target_properties(ireert PROPERTIES
+  ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/lib"
+  LIBRARY_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/lib"
+  RUNTIME_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/bin"
+)
+
+if(BUILD_SHARED_LIBS)
+  # Import symbols from library on use.
+  target_compile_options(ireert INTERFACE "-UIREE_API_BUILDING_LIBRARY")
+  # Disallow undefined symbols in shared library mode.
+  if(NOT IREE_ENABLE_ASAN
+    AND NOT IREE_ENABLE_MSAN
+    AND NOT IREE_ENABLE_TSAN
+    AND NOT IREE_ENABLE_UBSAN)
+    target_link_options(ireert PRIVATE
+      $<$<PLATFORM_ID:Linux>:-Wl,--no-undefined>
+      $<$<PLATFORM_ID:Darwin>:-Wl,-undefined,error>
+    )
+  endif()
+endif()
+
+#-------------------------------------------------------------------------------
+# Populate headers from the source tree.
+#-------------------------------------------------------------------------------
+
+# Copy source tree headers.
+function(_copy_runtime_source_headers)
+  set(_RUNTIME_HEADER_SOURCE_DIR "${IREE_ROOT_DIR}/runtime/src")
+  file(GLOB_RECURSE
+    _RUNTIME_SRC_HEADERS
+    RELATIVE "${_RUNTIME_HEADER_SOURCE_DIR}"
+    "${_RUNTIME_HEADER_SOURCE_DIR}/*.h")
+  foreach(_RUNTIME_HEADER ${_RUNTIME_SRC_HEADERS})
+    set(_src_file "${_RUNTIME_HEADER_SOURCE_DIR}/${_RUNTIME_HEADER}")
+    set(_dst_file "${CMAKE_CURRENT_BINARY_DIR}/include/${_RUNTIME_HEADER}")
+    get_filename_component(_parent_dir "${_dst_file}" DIRECTORY)
+    file(MAKE_DIRECTORY "${_parent_dir}")
+    file(COPY_FILE
+      "${_src_file}"
+      "${_dst_file}"
+      ONLY_IF_DIFFERENT)
+  endforeach()
+endfunction()
+_copy_runtime_source_headers()
+
+#-------------------------------------------------------------------------------
+# Generate a test program.
+#-------------------------------------------------------------------------------
+
+add_executable(ireert_test test_api.c)
+set_target_properties(ireert_test
+  PROPERTIES
+  RUNTIME_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/bin"
+)
+target_link_libraries(ireert_test PRIVATE ireert)

--- a/runtime-library/README.md
+++ b/runtime-library/README.md
@@ -19,6 +19,8 @@ the IREE repository proper as a standalone project.
 
 ## Options:
 
+* `-DIREE_ROOT_DIR=<path>` : Override the path to the main IREE repo. Defaults
+  to assuming that `iree` is checked out adjacent to `iree-samples`.
 * `-DBUILD_SHARED_LIBS=ON` : Builds a libireert.so (or corresponding DLL/dylib)
   for development use. Note that the low-level IREE runtime API is fine grained
   and usage in a shared library will pessimize optimizations. Therefore, this
@@ -41,7 +43,6 @@ C/library level, not the build system level.
 
 ```
 cmake -GNinja -Bbuild .
-cd build
-ninja
-./bin/ireert_test
+cmake --build build
+./build/bin/ireert_test
 ```

--- a/runtime-library/README.md
+++ b/runtime-library/README.md
@@ -1,0 +1,47 @@
+# IREE runtime library builder
+
+Integrators often like to link against a single runtime library, and the
+method of doing so is naturally owned by the integrator -- not necessarily
+by IREE itself (i.e. IREE will never release a full libireert.a). This
+separation of concerns is of practical importance because IREE's low level
+runtime API is fine-grained and geared towards usage via LTO style
+optimizations. This makes it inherently non-distributable, since every
+toolchain defines such features and interop differently.
+
+Also, it is often convenient during early development (of language bindings,
+etc) to simply dynamically link to something that works, even if not optimal.
+Because it cannot produce the best integration, IREE itself does not export
+a shared runtime library. However, to aid development, it can be useful
+for users to produce one.
+
+This sample illustrates both modes of use. It may eventually be included in
+the IREE repository proper as a standalone project.
+
+## Options:
+
+* `-DBUILD_SHARED_LIBS=ON` : Builds a libireert.so (or corresponding DLL/dylib)
+  for development use. Note that the low-level IREE runtime API is fine grained
+  and usage in a shared library will pessimize optimizations. Therefore, this
+  is only recommended for development or getting started.
+* `-DIREERT_ENABLE_LTO=ON` : Enables LTO if the toolchain supports it. This is
+  supported for both shared and static library builds, but for shared libraries,
+  the optimizations stop at the exported symbol boundary. As of early 2023,
+  this has the side effect of reducing the binary size by ~16%.
+
+## Using in external builds.
+
+When built, `lib/` and `include/` directories will be populated. It should
+be possible to use these with no further manipulation. While using the main
+`iree` project as a sub-project is recommended for those who can, using
+standalone headers and libraries is expected to benefit language bindings and
+other indirect uses of the API, since such tooling often interops at the
+C/library level, not the build system level.
+
+## Typical use
+
+```
+cmake -GNinja -Bbuild .
+cd build
+ninja
+./bin/ireert_test
+```

--- a/runtime-library/test_api.c
+++ b/runtime-library/test_api.c
@@ -1,0 +1,31 @@
+// Copyright 2023 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+// Simple test program that uses the HAL API to list available drivers.
+// This is just to ensure that it is possible to use the library.
+
+#include <iree/hal/api.h>
+#include <iree/hal/drivers/init.h>
+
+#include <stdio.h>
+
+int main(int argc, char **argv) {
+  iree_hal_driver_registry_t *registry = iree_hal_driver_registry_default();
+  IREE_CHECK_OK(iree_hal_register_all_available_drivers(registry));
+
+  iree_host_size_t driver_count;
+  iree_hal_driver_info_t *driver_infos;
+  IREE_CHECK_OK(iree_hal_driver_registry_enumerate(
+      registry, iree_allocator_system(), &driver_count, &driver_infos));
+
+  for (iree_host_size_t i = 0; i < driver_count; ++i) {
+    printf("Available driver: %.*s (%.*s)\n",
+           (int)driver_infos[i].driver_name.size,
+           driver_infos[i].driver_name.data,
+           (int)driver_infos[i].full_name.size, driver_infos[i].full_name.data);
+  }
+  return 0;
+}


### PR DESCRIPTION
Just starting in iree-samples for now since this will always be a special way to build the runtime for niche uses, and keeping it isolated allows it to be forked/adapted at need.

This should help people looking to build language bindings and other systematic integrations, and it gets us out of the business of having to support all of the ways the runtime build can be used (and abused) while lighting the path that we recommend. We likely need more discussion to make this a real thing but it is serviceable as-is.

Shared library support depends on https://github.com/iree-org/iree/pull/11723