### PR TITLE
Add facility to the PJRT plugin to save artifacts.

### DIFF
--- a/pjrt-plugin/README.md
+++ b/pjrt-plugin/README.md
@@ -12,6 +12,11 @@ there are sharp edges still. The following procedure is being used to develop.
 It is recommended to checkout `jax`, `iree`, `iree-samples`, and `tensorflow`
 side by side, as we will be overriding them all to build at head.
 
+Note that although Jax is emitting serialized stablehlo bytecode, which should
+be compatible across versions eventually, it is still early days and things
+are not stable yet. It is recommended to use a `tensorflow` repo at the same
+commit that IREE uses.
+
 ## Build and install custom jaxlib
 
 From a Jax checkout:

--- a/pjrt-plugin/iree/integrations/pjrt/common/dylib_platform.cc
+++ b/pjrt-plugin/iree/integrations/pjrt/common/dylib_platform.cc
@@ -76,6 +76,22 @@ iree_status_t DylibPlatform::SubclassInitialize() {
   // And initialize the compiler.
   compiler_ = std::make_unique<InprocessCompiler>();
 
+  // Initialize the artifact dumper.
+  auto artifact_path_spec = config_vars().Lookup("SAVE_ARTIFACTS");
+  if (!artifact_path_spec) {
+    artifact_dumper_ = std::make_unique<ArtifactDumper>();
+    logger().debug(
+        "Artifact dumping disabled. Enable by setting the 'SAVE_ARTIFACTS' "
+        "config var ('IREE_PJRT_SAVE_ARTIFACTS' env var)");
+  } else {
+    // TODO: Use a config key like "SAVE_ALL" to control all artifact saving.
+    artifact_dumper_ = std::make_unique<FilesArtifactDumper>(
+        logger(), *artifact_path_spec, /*retain_all=*/false);
+    std::string message("Dumping artifacts to: ");
+    message.append(artifact_dumper_->DebugString());
+    logger().debug(message);
+  }
+
   return iree_ok_status();
 }
 

--- a/pjrt-plugin/iree/integrations/pjrt/common/platform.cc
+++ b/pjrt-plugin/iree/integrations/pjrt/common/platform.cc
@@ -7,7 +7,10 @@
 #include "iree/integrations/pjrt/common/platform.h"
 
 #include <cstdlib>
+#include <filesystem>
+#include <fstream>
 #include <iostream>
+#include <vector>
 
 namespace iree::pjrt {
 
@@ -51,6 +54,134 @@ void Logger::error(std::string_view message) {
 }
 
 //===----------------------------------------------------------------------===//
+// ArtifactDumper
+//===----------------------------------------------------------------------===//
+
+ArtifactDumper::~ArtifactDumper() = default;
+
+std::unique_ptr<ArtifactDumper::Transaction>
+ArtifactDumper::CreateTransaction() {
+  return nullptr;
+}
+
+std::string ArtifactDumper::DebugString() { return std::string("disabled"); }
+
+//===----------------------------------------------------------------------===//
+// FilesArtifactDumper
+//===----------------------------------------------------------------------===//
+
+class FilesArtifactDumper::FilesTransaction
+    : public ArtifactDumper::Transaction {
+ public:
+  FilesTransaction(Logger& logger, std::filesystem::path base_path,
+                   int64_t transaction_id, bool retain_all)
+      : logger_(logger),
+        base_path_(std::move(base_path)),
+        transaction_id_(transaction_id),
+        retain_all_(retain_all) {}
+  ~FilesTransaction() { Retain(); }
+
+  void WriteArtifact(std::string_view label, std::string_view extension,
+                     int index, std::string_view contents) override {
+    std::string basename = std::to_string(transaction_id_);
+    basename.append("-");
+    basename.append(label);
+    if (index >= 0) {
+      basename.append(std::to_string(index));
+    }
+    basename.append(".");
+    basename.append(extension);
+
+    auto file_path = base_path_ / basename;
+    std::ofstream fout;
+    fout.open(file_path, std::ofstream::out | std::ofstream::trunc |
+                             std::ofstream::binary);
+    fout.write(contents.data(), contents.size());
+    fout.close();
+
+    written_paths_.push_back(file_path);
+
+    if (!fout.good()) {
+      std::string message("I/O error dumping artifact: ");
+      message.append(file_path);
+      logger_.error(message);
+    }
+  }
+
+  void Retain() override {
+    if (written_paths_.empty()) return;
+
+    std::string message;
+    message.append("Retained artifacts in: ");
+    message.append(base_path_);
+    for (auto& p : written_paths_) {
+      message.append("\n  ");
+      message.append(p.filename());
+    }
+    logger_.debug(message);
+
+    written_paths_.clear();
+  }
+
+  void Cancel() override {
+    if (retain_all_) {
+      Retain();
+      return;
+    }
+
+    for (auto& p : written_paths_) {
+      std::error_code ec;
+      std::filesystem::remove(p, ec);
+      if (ec) {
+        // Only carp as a debug message since there are legitimate reasons
+        // this can happen depending on what is going on at the system level.
+        std::string message("Error removing artifact: ");
+        message.append(p);
+        logger_.debug(message);
+      }
+    }
+
+    written_paths_.clear();
+  }
+
+ private:
+  Logger& logger_;
+  std::vector<std::filesystem::path> written_paths_;
+  std::filesystem::path base_path_;
+  int64_t transaction_id_;
+  bool retain_all_;
+};
+
+FilesArtifactDumper::FilesArtifactDumper(Logger& logger,
+                                         std::string_view path_spec,
+                                         bool retain_all)
+    : logger_(logger), retain_all_(retain_all) {
+  path_ = path_spec;
+  enabled_ = true;
+
+  std::error_code ec;
+  std::filesystem::create_directories(path_, ec);
+  if (ec) {
+    std::string message("Error creating artifact directory '");
+    message.append(path_);
+    message.append("' (artifact dumping disabled): ");
+    message.append(ec.message());
+    logger_.error(message);
+    enabled_ = false;
+  }
+}
+
+FilesArtifactDumper::~FilesArtifactDumper() = default;
+
+std::unique_ptr<ArtifactDumper::Transaction>
+FilesArtifactDumper::CreateTransaction() {
+  return std::make_unique<FilesTransaction>(
+      logger_, path_, next_transaction_id_.fetch_add(1), retain_all_);
+}
+
+std::string FilesArtifactDumper::DebugString() { return path_; }
+
+//===----------------------------------------------------------------------===//
 // Platform
 //===----------------------------------------------------------------------===//
 
@@ -59,7 +190,7 @@ Platform::~Platform() = default;
 iree_status_t Platform::Initialize() {
   IREE_RETURN_IF_ERROR(SubclassInitialize());
 
-  if (!logger_ || !compiler_) {
+  if (!logger_ || !compiler_ || !artifact_dumper_) {
     return iree_make_status(IREE_STATUS_FAILED_PRECONDITION,
                             "the Platform failed to initialize all objects");
   }

--- a/pjrt-plugin/iree/integrations/pjrt/common/platform.h
+++ b/pjrt-plugin/iree/integrations/pjrt/common/platform.h
@@ -7,8 +7,10 @@
 #ifndef IREE_PJRT_PLUGIN_PJRT_PLATFORM_H_
 #define IREE_PJRT_PLUGIN_PJRT_PLATFORM_H_
 
+#include <atomic>
 #include <functional>
 #include <optional>
+#include <string>
 #include <string_view>
 #include <unordered_map>
 
@@ -53,6 +55,87 @@ struct ConfigVars {
 };
 
 //===----------------------------------------------------------------------===//
+// ArtifactDumper
+// The typical modes of operation are:
+//   - Completely disabled
+//   - Enabled to persist all artifacts
+//   - Enabled to persist artifacts on recoverable errors (i.e. compile errors,
+//     etc)
+//   - Enabled to persist artifacts on crash only
+// Since we often don't know what the outcome of a transaction will be right
+// away, the transaction can be held open for some period of time and cancelled
+// later.
+//
+// In general, since this is a debugging facility, it swallows any errors,
+// reporting them to the Logger.
+//
+// The default implementation can be instantiated and is hard-coded to
+// !enabled().
+//===----------------------------------------------------------------------===//
+
+class ArtifactDumper {
+ public:
+  class Transaction {
+   public:
+    virtual ~Transaction() = default;
+
+    // Writes an artifact with a transaction-unique label/index.
+    virtual void WriteArtifact(std::string_view label,
+                               std::string_view extension, int index,
+                               std::string_view contents) = 0;
+
+    // Completes the transation and retains all artifacts.
+    virtual void Retain() = 0;
+
+    // Completes the transaction and removes all artifacts.
+    virtual void Cancel() = 0;
+  };
+
+  virtual ~ArtifactDumper();
+
+  // Not virtual for quick checks in disabled state.
+  bool enabled() { return enabled_; }
+
+  // Allocates a new transaction which can be used to append related
+  // artifacts. All artifacts associated with a transaction can be removed upon
+  // a successful transaction, or they will be retained upon crash or
+  // recoverable error.
+  // Must only be called if enabled().
+  virtual std::unique_ptr<Transaction> CreateTransaction();
+
+  // Returns a string suitable for emitting to the debug log, describing
+  // where and how artifacts will be retained.
+  virtual std::string DebugString();
+
+ protected:
+  bool enabled_ = false;
+};
+
+// Dumps artifacts to a path on the file system.
+// This is initialized with a path_spec. Currently, this is just a path on
+// the file system, but it should be brought into alignment with how the Python
+// side does it.
+// See:
+// https://github.com/iree-org/iree/blob/main/compiler/src/iree/compiler/API/python/iree/compiler/tools/debugging.py#L29
+class FilesArtifactDumper : public ArtifactDumper {
+ public:
+  class FilesTransaction;
+
+  FilesArtifactDumper(Logger& logger, std::string_view path_spec,
+                      bool retain_all);
+  ~FilesArtifactDumper() override;
+
+  std::unique_ptr<Transaction> CreateTransaction() override;
+  std::string DebugString() override;
+
+ private:
+  Logger& logger_;
+  std::atomic<int64_t> next_transaction_id_{0};
+  std::string path_;
+  bool retain_all_;
+};
+
+//===----------------------------------------------------------------------===//
 // Platform
 // Encapsulates aspects of the platform which may differ under different
 // usage and/or environments.
@@ -65,12 +148,14 @@ class Platform {
   ConfigVars& config_vars() { return config_vars_; }
   Logger& logger() { return *logger_; }
   AbstractCompiler& compiler() { return *compiler_; }
+  ArtifactDumper& artifact_dumper() { return *artifact_dumper_; }
 
  protected:
   virtual iree_status_t SubclassInitialize() = 0;
   ConfigVars config_vars_;
   std::unique_ptr<Logger> logger_;
   std::unique_ptr<AbstractCompiler> compiler_;
+  std::unique_ptr<ArtifactDumper> artifact_dumper_;
 };
 
 }  // namespace iree::pjrt


### PR DESCRIPTION
This can be enabled in the default build via IREE_PJRT_SAVE_ARTIFACTS environment variable. Some effort has been made to allow this to be extended for custom platforms and integration of reproducers.