### PR TITLE
Enable building ireert frameworks and the XCFramework 

### DIFF
--- a/runtime-library/CMakeLists.txt
+++ b/runtime-library/CMakeLists.txt
@@ -53,12 +53,48 @@ add_subdirectory("${IREE_ROOT_DIR}" "iree_core" EXCLUDE_FROM_ALL)
 set(_RUNTIME_ROOT_TARGET "iree::runtime::impl")
 set(_RUNTIME_OBJECTS "$<REMOVE_DUPLICATES:$<GENEX_EVAL:$<TARGET_PROPERTY:${_RUNTIME_ROOT_TARGET},INTERFACE_IREE_TRANSITIVE_OBJECTS>>>")
 set(_RUNTIME_LIBS "$<REMOVE_DUPLICATES:$<GENEX_EVAL:$<TARGET_PROPERTY:${_RUNTIME_ROOT_TARGET},INTERFACE_IREE_TRANSITIVE_OBJECT_LIBS>>>")
- # For debugging, write out objects and deps to files.
+# For debugging, write out objects and deps to files.
 file(GENERATE OUTPUT "lib/ireert.objects.txt" CONTENT "${_RUNTIME_OBJECTS}\n")
 file(GENERATE OUTPUT "lib/ireert.libs.txt" CONTENT "${_RUNTIME_LIBS}\n")
 
+# List all of the headers so that we can add them when we call add
+# library. This has to be done so that these headers files can be
+# added to the macOS/iOS
+# framework. c.f. https://gitlab.kitware.com/cmake/cmake/-/issues/16739#note_641049
+#
+# It doesn't work if we add these headers later using target_sources.
+#
+# Even though these headers are listed in add_library, that is not yet
+# enough to add them to the framework. We need to add them to
+#
+#   set_target_property(ireert PROPERTIES PUBLIC_HEADER header_files)
+#
+# for that to happen. Unfortunately, CMake would flatten the directory
+# structure of the header files and put all header files in the
+# framework's "Headers/" directory. In the case of IREE runtime, we
+# will have two debugging.h files in the same directory, so it doesn't
+# work.
+#
+# We could also call
+#
+#  set_source_files_properties(
+#     a_header PROPERTIES MACOSX_PACKAGE_LOCATION Headers/where_it_goes)
+#
+# for each header file, which is what we will do later in this
+# file. Note that this method doesn't work with PUBLIC_HEADER, so we
+# can't use both of them at the same
+# time. c.f. https://gitlab.kitware.com/cmake/cmake/-/issues/16739#note_641095
+set(_RUNTIME_HEADER_SOURCE_DIR "${IREE_ROOT_DIR}/runtime/src")
+file(GLOB_RECURSE
+  _RUNTIME_SRC_HEADERS_FULLPATH
+  "${_RUNTIME_HEADER_SOURCE_DIR}/*.h")
+
+
 # Build the library (shared or static).
-add_library(ireert ${_RUNTIME_OBJECTS})
+add_library(ireert
+  ${_RUNTIME_OBJECTS}
+  ${_RUNTIME_SRC_HEADERS_FULLPATH}
+)
 target_include_directories(ireert INTERFACE "${CMAKE_CURRENT_BINARY_DIR}/include")
 target_link_libraries(ireert PUBLIC ${_RUNTIME_LIBS})
 set_target_properties(ireert PROPERTIES
@@ -80,6 +116,26 @@ if(BUILD_SHARED_LIBS)
       $<$<PLATFORM_ID:Darwin>:-Wl,-undefined,error>
     )
   endif()
+endif()
+
+
+if(APPLE)
+  set_target_properties(ireert PROPERTIES
+    FRAMEWORK TRUE
+    FRAMEWORK_VERSION A
+    MACOSX_FRAMEWORK_IDENTIFIER dev.iree.ireert
+    VERSION 16.4.0
+    SOVERSION 1.0.0
+    XCODE_ATTRIBUTE_CODE_SIGNING_REQUIRED OFF
+    PUBLIC_HEADER "${_RUNTIME_SRC_HEADERS_FULL_PATH}"
+  )
+
+  foreach(_RUNTIME_HEADER ${_RUNTIME_SRC_HEADERS_FULLPATH})
+    string(REPLACE ${_RUNTIME_HEADER_SOURCE_DIR}/ "" _RUNTIME_HEADER_RELPATH ${_RUNTIME_HEADER})
+    get_filename_component(_REL_DIR "${_RUNTIME_HEADER_RELPATH}" DIRECTORY)
+    set_source_files_properties(
+      ${_RUNTIME_HEADER} PROPERTIES MACOSX_PACKAGE_LOCATION Headers/${_REL_DIR})
+  endforeach()
 endif()
 
 #-------------------------------------------------------------------------------

--- a/runtime-library/CMakeLists.txt
+++ b/runtime-library/CMakeLists.txt
@@ -15,13 +15,16 @@ set(IREE_ROOT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../iree" CACHE STRING "Main IR
 option(IREERT_ENABLE_LTO "Enable LTO (link time optimization) if supported" ON)
 include(CheckIPOSupported)
 check_ipo_supported(RESULT _ireert_lto_supported OUTPUT error)
-if(IREERT_ENABLE_LTO)
-  if(_ireert_lto_supported)
-    message(STATUS "Enabling LTO")
-    set(CMAKE_INTERPROCEDURAL_OPTIMIZATION ON)
-  else()
-    message(WARNING "LTO not supported by toolchain bit requested (ignored)")
-  endif()
+if(NOT _ireert_lto_supported)
+  message(WARNING "LTO not supported by toolchain bit requested (ignored)")
+endif()
+if(IREERT_ENABLE_LTO AND _ireert_lto_supported AND NOT APPLE)
+  # Enabling LTO on macOS/iOS is fine to build frameworks. But when we merge
+  # them into an XCframework using the command
+  # xcodebuild -create-xcframework -framework build-ios-sim/ireert.framework ...
+  # it will complain "unable to find any architecture information in the binary".
+  message(STATUS "Enabling LTO")
+  set(CMAKE_INTERPROCEDURAL_OPTIMIZATION ON)
 endif()
 
 # Optionally enabled shared library build mode. This is only supported for

--- a/runtime-library/README.md
+++ b/runtime-library/README.md
@@ -17,7 +17,7 @@ for users to produce one.
 This sample illustrates both modes of use. It may eventually be included in
 the IREE repository proper as a standalone project.
 
-## Options:
+## Options
 
 * `-DIREE_ROOT_DIR=<path>` : Override the path to the main IREE repo. Defaults
   to assuming that `iree` is checked out adjacent to `iree-samples`.
@@ -30,7 +30,7 @@ the IREE repository proper as a standalone project.
   the optimizations stop at the exported symbol boundary. As of early 2023,
   this has the side effect of reducing the binary size by ~16%.
 
-## Using in external builds.
+## Using in external builds
 
 When built, `lib/` and `include/` directories will be populated. It should
 be possible to use these with no further manipulation. While using the main
@@ -46,6 +46,10 @@ cmake -GNinja -Bbuild .
 cmake --build build
 ./build/bin/ireert_test
 ```
+
+If we run the above commands on macOS, we will get
+`build/lib/ireert.framework`, which includes the static library and
+header files.
 
 ## Build for iOS
 
@@ -64,9 +68,9 @@ cmake -S . -B build-ios-sim -GNinja \
   -DCMAKE_INSTALL_PREFIX=../build-ios-sim/install \
   -DIREE_BUILD_COMPILER=OFF
   
-cmake --build build
+cmake --build build-ios-sim
 ```
 
-This will give us the test binary `build-ios-sim/bin/ireert_test.app` and the IREE runtime library `build-ios-sim/lib/libireert.a`.
+This will give us the app bundle `build-ios-sim/bin/ireert_test.app` and the IREE runtime framework `build-ios-sim/lib/ireert.framework`.
 
 To configure and build for iOS devices, we can change `-DCMAKE_OSX_SYSROOT=$(xcodebuild -version -sdk iphonesimulator Path)` into `-DCMAKE_OSX_SYSROOT=$(xcodebuild -version -sdk iphoneos Path)`.

--- a/runtime-library/create_xcframework.sh
+++ b/runtime-library/create_xcframework.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+SCRIPT_DIR=$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")
+IREE_HOST_BUILD_DIR=$SCRIPT_DIR/../../iree-build/install/bin
+
+if [[ ! -x $IREE_HOST_BUILD_DIR/iree-compile ]]; then
+    echo "Please build IREE for the host https://iree-org.github.io/iree/building-from-source/ios/#configure-and-build"
+    exit 1
+fi
+
+echo "Building for the host ..."
+cmake -GNinja -Bbuild . &&
+cmake --build build
+
+echo "Building for the iOS Simulator ..."
+cmake -S . -B build-ios-sim -GNinja \
+  -DCMAKE_SYSTEM_NAME=iOS \
+  -DCMAKE_OSX_SYSROOT=$(xcodebuild -version -sdk iphonesimulator Path) \
+  -DCMAKE_OSX_ARCHITECTURES=arm64 \
+  -DCMAKE_SYSTEM_PROCESSOR=arm64 \
+  -DCMAKE_OSX_DEPLOYMENT_TARGET=11.0 \
+  -DCMAKE_IOS_INSTALL_COMBINED=YES \
+  -DIREE_HOST_BIN_DIR="$HOME/w/iree-build/install/bin" \
+  -DCMAKE_INSTALL_PREFIX=../build-ios-sim/install \
+  -DIREE_BUILD_COMPILER=OFF &&  
+cmake --build build-ios-sim
+
+echo "Building for iOS devices ..."
+cmake -S . -B build-ios-dev -GNinja \
+  -DCMAKE_SYSTEM_NAME=iOS \
+  -DCMAKE_OSX_SYSROOT=$(xcodebuild -version -sdk iphoneos Path) \
+  -DCMAKE_OSX_ARCHITECTURES=arm64 \
+  -DCMAKE_SYSTEM_PROCESSOR=arm64 \
+  -DCMAKE_OSX_DEPLOYMENT_TARGET=11.0 \
+  -DCMAKE_IOS_INSTALL_COMBINED=YES \
+  -DIREE_HOST_BIN_DIR="$HOME/w/iree-build/install/bin" \
+  -DCMAKE_INSTALL_PREFIX=../build-ios-dev/install \
+  -DIREE_BUILD_COMPILER=OFF &&  
+cmake --build build-ios-dev
+
+echo "Aggregating frameworks into an xcframework ..."
+rm -rf ireert.xcframework
+xcodebuild -create-xcframework \
+ 	   -framework build/lib/ireert.framework \
+ 	   -framework build-ios-sim/lib/ireert.framework \
+ 	   -framework build-ios-dev/lib/ireert.framework \
+	   -output ireert.xcframework
+


### PR DESCRIPTION
- Building IREE runtime for macOS/iOS generates not only the static library, but the framework consisting the static library and header files.

- Automate the building of frameworks for macOS, iOS, and iOS simulator, and the merging of them into an XCFramework to ease Xcode developers' work.

- Update the README.md file.