### PR TITLE
Rename the library name ireert into iree

### DIFF
--- a/runtime-library/CMakeLists.txt
+++ b/runtime-library/CMakeLists.txt
@@ -24,13 +24,16 @@ endif()
 
 include(CheckIPOSupported)
 check_ipo_supported(RESULT _ireert_lto_supported OUTPUT error)
-if(IREERT_ENABLE_LTO)
-  if(_ireert_lto_supported)
-    message(STATUS "Enabling LTO")
-    set(CMAKE_INTERPROCEDURAL_OPTIMIZATION ON)
-  else()
-    message(WARNING "LTO not supported by toolchain bit requested (ignored)")
-  endif()
+if(NOT _ireert_lto_supported)
+  message(WARNING "LTO not supported by toolchain bit requested (ignored)")
+endif()
+if(IREERT_ENABLE_LTO AND _ireert_lto_supported AND NOT APPLE)
+  # Enabling LTO on macOS/iOS is fine to build frameworks. But when we merge
+  # them into an XCframework using the command
+  # xcodebuild -create-xcframework -framework build-ios-sim/ireert.framework ...
+  # it will complain "unable to find any architecture information in the binary".
+  message(STATUS "Enabling LTO")
+  set(CMAKE_INTERPROCEDURAL_OPTIMIZATION ON)
 endif()
 
 # Optionally enabled shared library build mode. This is only supported for

--- a/runtime-library/CMakeLists.txt
+++ b/runtime-library/CMakeLists.txt
@@ -55,7 +55,7 @@ option(IREE_BUILD_SAMPLES "Disable samples for runtime-library build" OFF)
 add_subdirectory("${IREE_ROOT_DIR}" "iree_core" EXCLUDE_FROM_ALL)
 
 #-------------------------------------------------------------------------------
-# Build the ireert library
+# Build the iree library
 #-------------------------------------------------------------------------------
 
 # IREE exposes its transitive objects and deps on special target properties.
@@ -63,8 +63,8 @@ set(_RUNTIME_ROOT_TARGET "iree::runtime::impl")
 set(_RUNTIME_OBJECTS "$<REMOVE_DUPLICATES:$<GENEX_EVAL:$<TARGET_PROPERTY:${_RUNTIME_ROOT_TARGET},INTERFACE_IREE_TRANSITIVE_OBJECTS>>>")
 set(_RUNTIME_LIBS "$<REMOVE_DUPLICATES:$<GENEX_EVAL:$<TARGET_PROPERTY:${_RUNTIME_ROOT_TARGET},INTERFACE_IREE_TRANSITIVE_OBJECT_LIBS>>>")
 # For debugging, write out objects and deps to files.
-file(GENERATE OUTPUT "lib/ireert.objects.txt" CONTENT "${_RUNTIME_OBJECTS}\n")
-file(GENERATE OUTPUT "lib/ireert.libs.txt" CONTENT "${_RUNTIME_LIBS}\n")
+file(GENERATE OUTPUT "lib/iree.objects.txt" CONTENT "${_RUNTIME_OBJECTS}\n")
+file(GENERATE OUTPUT "lib/iree.libs.txt" CONTENT "${_RUNTIME_LIBS}\n")
 
 # List all of the headers so that we can add them when we call add
 # library. This has to be done so that these headers files can be
@@ -76,7 +76,7 @@ file(GENERATE OUTPUT "lib/ireert.libs.txt" CONTENT "${_RUNTIME_LIBS}\n")
 # Even though these headers are listed in add_library, that is not yet
 # enough to add them to the framework. We need to add them to
 #
-#   set_target_property(ireert PROPERTIES PUBLIC_HEADER header_files)
+#   set_target_property(iree PROPERTIES PUBLIC_HEADER header_files)
 #
 # for that to happen. Unfortunately, CMake would flatten the directory
 # structure of the header files and put all header files in the
@@ -100,13 +100,13 @@ file(GLOB_RECURSE
 
 
 # Build the library (shared or static).
-add_library(ireert
+add_library(iree
   ${_RUNTIME_OBJECTS}
   ${_RUNTIME_SRC_HEADERS_FULLPATH}
 )
-target_include_directories(ireert INTERFACE "${CMAKE_CURRENT_BINARY_DIR}/include")
-target_link_libraries(ireert PUBLIC ${_RUNTIME_LIBS})
-set_target_properties(ireert PROPERTIES
+target_include_directories(iree INTERFACE "${CMAKE_CURRENT_BINARY_DIR}/include")
+target_link_libraries(iree PUBLIC ${_RUNTIME_LIBS})
+set_target_properties(iree PROPERTIES
   ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/lib"
   LIBRARY_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/lib"
   RUNTIME_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/bin"
@@ -114,13 +114,13 @@ set_target_properties(ireert PROPERTIES
 
 if(BUILD_SHARED_LIBS)
   # Import symbols from library on use.
-  target_compile_options(ireert INTERFACE "-UIREE_API_BUILDING_LIBRARY")
+  target_compile_options(iree INTERFACE "-UIREE_API_BUILDING_LIBRARY")
   # Disallow undefined symbols in shared library mode.
   if(NOT IREE_ENABLE_ASAN
     AND NOT IREE_ENABLE_MSAN
     AND NOT IREE_ENABLE_TSAN
     AND NOT IREE_ENABLE_UBSAN)
-    target_link_options(ireert PRIVATE
+    target_link_options(iree PRIVATE
       $<$<PLATFORM_ID:Linux>:-Wl,--no-undefined>
       $<$<PLATFORM_ID:Darwin>:-Wl,-undefined,error>
     )
@@ -129,10 +129,10 @@ endif()
 
 
 if(APPLE)
-  set_target_properties(ireert PROPERTIES
+  set_target_properties(iree PROPERTIES
     FRAMEWORK TRUE
     FRAMEWORK_VERSION A
-    MACOSX_FRAMEWORK_IDENTIFIER dev.iree.ireert
+    MACOSX_FRAMEWORK_IDENTIFIER dev.iree.iree
     VERSION 16.4.0
     SOVERSION 1.0.0
     XCODE_ATTRIBUTE_CODE_SIGNING_REQUIRED OFF
@@ -140,7 +140,7 @@ if(APPLE)
   )
 
   foreach(_RUNTIME_HEADER ${_RUNTIME_SRC_HEADERS_FULLPATH})
-    string(REPLACE ${_RUNTIME_HEADER_SOURCE_DIR}/ "" _RUNTIME_HEADER_RELPATH ${_RUNTIME_HEADER})
+    string(REPLACE ${_RUNTIME_HEADER_SOURCE_DIR}/iree "" _RUNTIME_HEADER_RELPATH ${_RUNTIME_HEADER})
     get_filename_component(_REL_DIR "${_RUNTIME_HEADER_RELPATH}" DIRECTORY)
     set_source_files_properties(
       ${_RUNTIME_HEADER} PROPERTIES MACOSX_PACKAGE_LOCATION Headers/${_REL_DIR})
@@ -175,9 +175,9 @@ _copy_runtime_source_headers()
 # Generate a test program.
 #-------------------------------------------------------------------------------
 
-add_executable(ireert_test test_api.c)
-set_target_properties(ireert_test
+add_executable(iree_test test_api.c)
+set_target_properties(iree_test
   PROPERTIES
   RUNTIME_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/bin"
 )
-target_link_libraries(ireert_test PRIVATE ireert)
+target_link_libraries(iree_test PRIVATE iree)

--- a/runtime-library/CMakeLists.txt
+++ b/runtime-library/CMakeLists.txt
@@ -24,16 +24,13 @@ endif()
 
 include(CheckIPOSupported)
 check_ipo_supported(RESULT _ireert_lto_supported OUTPUT error)
-if(NOT _ireert_lto_supported)
-  message(WARNING "LTO not supported by toolchain bit requested (ignored)")
-endif()
-if(IREERT_ENABLE_LTO AND _ireert_lto_supported AND NOT APPLE)
-  # Enabling LTO on macOS/iOS is fine to build frameworks. But when we merge
-  # them into an XCframework using the command
-  # xcodebuild -create-xcframework -framework build-ios-sim/ireert.framework ...
-  # it will complain "unable to find any architecture information in the binary".
-  message(STATUS "Enabling LTO")
-  set(CMAKE_INTERPROCEDURAL_OPTIMIZATION ON)
+if(IREERT_ENABLE_LTO)
+  if(_ireert_lto_supported)
+    message(STATUS "Enabling LTO")
+    set(CMAKE_INTERPROCEDURAL_OPTIMIZATION ON)
+  else()
+    message(WARNING "LTO not supported by toolchain bit requested (ignored)")
+  endif()
 endif()
 
 # Optionally enabled shared library build mode. This is only supported for

--- a/runtime-library/README.md
+++ b/runtime-library/README.md
@@ -74,15 +74,3 @@ cmake --build build-ios-sim
 This will give us the app bundle `build-ios-sim/bin/ireert_test.app` and the IREE runtime framework `build-ios-sim/lib/ireert.framework`.
 
 To configure and build for iOS devices, we can change `-DCMAKE_OSX_SYSROOT=$(xcodebuild -version -sdk iphonesimulator Path)` into `-DCMAKE_OSX_SYSROOT=$(xcodebuild -version -sdk iphoneos Path)`.
-
-## Build Apple XCFramework
-
-An [XCFramework
-bundle](https://developer.apple.com/documentation/xcode/creating-a-multi-platform-binary-framework-bundle)
-is a binary package created by Xcode that includes the frameworks and
-libraries necessary to build for multiple platforms (iOS, macOS, tvOS,
-and watchOS), including Simulator builds.  Run the following command to build the `ireert.xcframework`.
-
-```
-./create_xcframework.sh
-```

--- a/runtime-library/README.md
+++ b/runtime-library/README.md
@@ -74,3 +74,15 @@ cmake --build build-ios-sim
 This will give us the app bundle `build-ios-sim/bin/ireert_test.app` and the IREE runtime framework `build-ios-sim/lib/ireert.framework`.
 
 To configure and build for iOS devices, we can change `-DCMAKE_OSX_SYSROOT=$(xcodebuild -version -sdk iphonesimulator Path)` into `-DCMAKE_OSX_SYSROOT=$(xcodebuild -version -sdk iphoneos Path)`.
+
+## Build Apple XCFramework
+
+An [XCFramework
+bundle](https://developer.apple.com/documentation/xcode/creating-a-multi-platform-binary-framework-bundle)
+is a binary package created by Xcode that includes the frameworks and
+libraries necessary to build for multiple platforms (iOS, macOS, tvOS,
+and watchOS), including Simulator builds.  Run the following command to build the `ireert.xcframework`.
+
+```
+./create_xcframework.sh
+```

--- a/runtime-library/create_xcframework.sh
+++ b/runtime-library/create_xcframework.sh
@@ -39,10 +39,10 @@ cmake -S . -B build-ios-dev -GNinja \
 cmake --build build-ios-dev
 
 echo "Aggregating frameworks into an xcframework ..."
-rm -rf ireert.xcframework
+rm -rf iree.xcframework
 xcodebuild -create-xcframework \
- 	   -framework build/lib/ireert.framework \
- 	   -framework build-ios-sim/lib/ireert.framework \
- 	   -framework build-ios-dev/lib/ireert.framework \
-	   -output ireert.xcframework
+ 	   -framework build/lib/iree.framework \
+ 	   -framework build-ios-sim/lib/iree.framework \
+ 	   -framework build-ios-dev/lib/iree.framework \
+	   -output iree.xcframework
 


### PR DESCRIPTION
## The Problem

Currently, for macOS and iOS, we build the IREE runtime into `ireert.framework`. Header files in [`/runtime/src`](https://github.com/iree-org/iree/tree/main/runtime/src) is copied to the directory `Headers/iree` of `ireert.framework`.  Following the convention of Objective-C, in an iOS app, we can import an IREE header file from the framework as the following:
```
#import "ireert/iree/base/status.h"
```

where `ireert` is the framework name, `iree` is the directory in `Headers`.

Unfortunately, the build of our Objective-C app would fail because in `status.h`, there are lines like the following.
```
#include "iree/base/attributes.h"
```

Note that this include path does not start with `ireert`, so the compiler complains not found header file "attributes.h".

## Idea 1.  Change the IREE runtime code.

A straightforward idea is to change the IREE source code and replace the above line into
```
#include "ireert/iree/base/attributes.h"
```

This does not make sense because the IREE authors, when writing the runtime code, have no idea that we will build their work into a framework named `ireert`.

## Idea 2. Add search path in the ireert.framework in Xcode

In Xcode, we can add `$(SRCROOT)/ireert.xcframework/arm64-ios-sim/ireert.framework/Headers/iree` to the search path, so the compiler can find file like `"iree/base/attributes.h"`.

This is not ideal because we will need to manually add paths for each platform in the XCFramework.  We might support more and more platforms in the future, including tvOS and watchOS.

## Idea 3. Rename ireert into iree

**This is what this pull request does.**

In addition to renaming the framework/xcframework, we also change the mapping of header files.  Rather than mapping `iree/runtime/src/*`, we map`iree/runtime/src/iree` to `Headers`.

After the name changing, in our iOS app, we do
```
#import "iree/base/status.h"
```
instead of
```
#import "ireert/iree/base/status.h".
```
Here, `iree` is the framework/xcframework name, and `base/status.h` is in `Headers`.

This import has the same convention as we already have in the IREE source code, i.e.,
```
#include "iree/base/attributes.h"
```

## The Result

The following screenshot shows an iOS app developed with Xcode.

- I added the new `iree.xcframework` into this Xcode project.  This XCFramework includes multiple `iree.framework`s, each built for a certain platform.
- In the Objective-C code, I put `#import "iree/base/status.h"` to include `status.h` from the XCFramework.
- In the `status.h` file, it can just `#include "iree/base/attributes.h" as is.
- The Output windows at the bottom of the screenshot shows "OK", which was printed by the call to `iree_status_fprint`.

<img width="1179" alt="Screenshot 2023-01-18 at 2 52 27 PM" src="https://user-images.githubusercontent.com/1548775/213323866-e046f682-984d-4f0d-baa4-dc13a6acbbf5.png">
