### PR TITLE
[runtime-library] Include runtime/src/iree/tooling in the runtime release

### DIFF
--- a/runtime-library/.gitignore
+++ b/runtime-library/.gitignore
@@ -1,0 +1,2 @@
+build*
+*.xcframework

--- a/runtime-library/CMakeLists.txt
+++ b/runtime-library/CMakeLists.txt
@@ -24,13 +24,16 @@ endif()
 
 include(CheckIPOSupported)
 check_ipo_supported(RESULT _ireert_lto_supported OUTPUT error)
-if(IREERT_ENABLE_LTO)
-  if(_ireert_lto_supported)
-    message(STATUS "Enabling LTO")
-    set(CMAKE_INTERPROCEDURAL_OPTIMIZATION ON)
-  else()
-    message(WARNING "LTO not supported by toolchain bit requested (ignored)")
-  endif()
+if(NOT _ireert_lto_supported)
+  message(WARNING "LTO not supported by toolchain bit requested (ignored)")
+endif()
+if(IREERT_ENABLE_LTO AND _ireert_lto_supported AND NOT APPLE)
+  # Enabling LTO on macOS/iOS is fine to build frameworks. But when we merge
+  # them into an XCframework using the command
+  # xcodebuild -create-xcframework -framework build-ios-sim/ireert.framework ...
+  # it will complain "unable to find any architecture information in the binary".
+  message(STATUS "Enabling LTO")
+  set(CMAKE_INTERPROCEDURAL_OPTIMIZATION ON)
 endif()
 
 # Optionally enabled shared library build mode. This is only supported for

--- a/runtime-library/CMakeLists.txt
+++ b/runtime-library/CMakeLists.txt
@@ -24,16 +24,13 @@ endif()
 
 include(CheckIPOSupported)
 check_ipo_supported(RESULT _ireert_lto_supported OUTPUT error)
-if(NOT _ireert_lto_supported)
-  message(WARNING "LTO not supported by toolchain bit requested (ignored)")
-endif()
-if(IREERT_ENABLE_LTO AND _ireert_lto_supported AND NOT APPLE)
-  # Enabling LTO on macOS/iOS is fine to build frameworks. But when we merge
-  # them into an XCframework using the command
-  # xcodebuild -create-xcframework -framework build-ios-sim/ireert.framework ...
-  # it will complain "unable to find any architecture information in the binary".
-  message(STATUS "Enabling LTO")
-  set(CMAKE_INTERPROCEDURAL_OPTIMIZATION ON)
+if(IREERT_ENABLE_LTO)
+  if(_ireert_lto_supported)
+    message(STATUS "Enabling LTO")
+    set(CMAKE_INTERPROCEDURAL_OPTIMIZATION ON)
+  else()
+    message(WARNING "LTO not supported by toolchain bit requested (ignored)")
+  endif()
 endif()
 
 # Optionally enabled shared library build mode. This is only supported for

--- a/runtime-library/CMakeLists.txt
+++ b/runtime-library/CMakeLists.txt
@@ -59,7 +59,13 @@ add_subdirectory("${IREE_ROOT_DIR}" "iree_core" EXCLUDE_FROM_ALL)
 #-------------------------------------------------------------------------------
 
 # IREE exposes its transitive objects and deps on special target properties.
-set(_RUNTIME_ROOT_TARGET "iree::runtime::impl")
+#
+# BUG(wangkuiyi): iree::tooling is not part of the official API.  I
+# use it as a walkaround of
+# https://github.com/iree-org/iree-samples/issues/100 The correct
+# target should be iree::runtime::impl in a normal CMake target name
+# with underscores other than the double-colons.
+set(_RUNTIME_ROOT_TARGET "iree::tooling::impl")
 set(_RUNTIME_OBJECTS "$<REMOVE_DUPLICATES:$<GENEX_EVAL:$<TARGET_PROPERTY:${_RUNTIME_ROOT_TARGET},INTERFACE_IREE_TRANSITIVE_OBJECTS>>>")
 set(_RUNTIME_LIBS "$<REMOVE_DUPLICATES:$<GENEX_EVAL:$<TARGET_PROPERTY:${_RUNTIME_ROOT_TARGET},INTERFACE_IREE_TRANSITIVE_OBJECT_LIBS>>>")
 # For debugging, write out objects and deps to files.
@@ -104,6 +110,7 @@ add_library(iree
   ${_RUNTIME_OBJECTS}
   ${_RUNTIME_SRC_HEADERS_FULLPATH}
 )
+
 target_include_directories(iree INTERFACE "${CMAKE_CURRENT_BINARY_DIR}/include")
 target_link_libraries(iree PUBLIC ${_RUNTIME_LIBS})
 set_target_properties(iree PROPERTIES

--- a/runtime-library/README.md
+++ b/runtime-library/README.md
@@ -74,15 +74,3 @@ cmake --build build-ios-sim
 This will give us the app bundle `build-ios-sim/bin/ireert_test.app` and the IREE runtime framework `build-ios-sim/lib/ireert.framework`.
 
 To configure and build for iOS devices, we can change `-DCMAKE_OSX_SYSROOT=$(xcodebuild -version -sdk iphonesimulator Path)` into `-DCMAKE_OSX_SYSROOT=$(xcodebuild -version -sdk iphoneos Path)`.
-
-## Build Apple XCFramework
-
-An [XCFramework
-bundle](https://developer.apple.com/documentation/xcode/creating-a-multi-platform-binary-framework-bundle)
-is a binary package created by Xcode that includes the frameworks and
-libraries necessary to build for multiple platforms (iOS, macOS, tvOS,
-and watchOS), including Simulator builds.  Run the following command to build the `ireert.xcframework`.
-
-```
-./create_xcframework.sh
-```

--- a/runtime-library/README.md
+++ b/runtime-library/README.md
@@ -74,3 +74,15 @@ cmake --build build-ios-sim
 This will give us the app bundle `build-ios-sim/bin/ireert_test.app` and the IREE runtime framework `build-ios-sim/lib/ireert.framework`.
 
 To configure and build for iOS devices, we can change `-DCMAKE_OSX_SYSROOT=$(xcodebuild -version -sdk iphonesimulator Path)` into `-DCMAKE_OSX_SYSROOT=$(xcodebuild -version -sdk iphoneos Path)`.
+
+## Build Apple XCFramework
+
+An [XCFramework
+bundle](https://developer.apple.com/documentation/xcode/creating-a-multi-platform-binary-framework-bundle)
+is a binary package created by Xcode that includes the frameworks and
+libraries necessary to build for multiple platforms (iOS, macOS, tvOS,
+and watchOS), including Simulator builds.  Run the following command to build the `ireert.xcframework`.
+
+```
+./create_xcframework.sh
+```


### PR DESCRIPTION
Fix https://github.com/iree-org/iree-samples/issues/100

This is a hacky fix. I added more TODO and BUG comments to remind us to redo this in the future.

As discussed in https://github.com/iree-org/iree-samples/issues/100, the ideal solution is to polish code in [`runtime/src/iree/tooling`](https://github.com/iree-org/iree/blob/main/runtime/src/iree/tooling/) for the use of app developers.

To make a prototype, we could accept a compromised solution - to copy-n-paste code from [`runtime/src/iree/tooling`](https://github.com/iree-org/iree/blob/main/runtime/src/iree/tooling/) to the prototype app.  However, I tried and found that there are too much code to copy.

Therefore, this pull request includes [`runtime/src/iree/tooling`](https://github.com/iree-org/iree/blob/main/runtime/src/iree/tooling/) into the IREE runtime release.  And it works.

<img width="1306" alt="Screenshot 2023-01-20 at 1 38 56 PM" src="https://user-images.githubusercontent.com/1548775/213823660-b44cdead-0c1c-4c6b-97fa-9a3c0396b412.png">

The above screenshot shows an app running in the simulator executes a simple vmfb, which, given the input `-5`, returns its absolute value `5` as expected.