### PR TITLE
remove XFAIL from lightning_test.py

### DIFF
--- a/tflitehub/lightning_test.py
+++ b/tflitehub/lightning_test.py
@@ -1,5 +1,4 @@
 # RUN: %PYTHON %s
-# XFAIL: *
 
 import absl.testing
 import numpy


### PR DESCRIPTION
The segfault in the test was caused by the alignment issue solved by https://github.com/iree-org/iree/pull/11952. Now that the fix is in the test is no longer failing