### PR TITLE
[transform_dialect] Explicitly set the value for the `jit`

### DIFF
--- a/transform_dialect/scripts.sh
+++ b/transform_dialect/scripts.sh
@@ -97,7 +97,7 @@ function iree-transform-opt() {
     if test ${CODEGEN_SPEC_FILE} == /dev/null; then
       CODEGEN_FLAG=${CODEGEN_FLAG}" --iree-codegen-llvmgpu-enable-transform-dialect-jit"
     else
-      CODEGEN_FLAG=${CODEGEN_FLAG}" --iree-codegen-llvmgpu-use-transform-dialect=${CODEGEN_SPEC_FILE}"
+      CODEGEN_FLAG=${CODEGEN_FLAG}" --iree-codegen-llvmgpu-enable-transform-dialect-jit=false --iree-codegen-llvmgpu-use-transform-dialect=${CODEGEN_SPEC_FILE}"
     fi
     CODEGEN_FLAG="${CODEGEN_FLAG} ${TRANSFORM_REPRO_FLAG}"
   elif test ${BACKEND} == llvm-cpu; then
@@ -105,7 +105,7 @@ function iree-transform-opt() {
     if test ${CODEGEN_SPEC_FILE} == /dev/null; then
       CODEGEN_FLAG=${CODEGEN_FLAG}" --iree-codegen-llvmcpu-enable-transform-dialect-jit"
     else
-      CODEGEN_FLAG=${CODEGEN_FLAG}" --iree-codegen-llvmcpu-use-transform-dialect=${CODEGEN_SPEC_FILE}"
+      CODEGEN_FLAG=${CODEGEN_FLAG}" --iree-codegen-llvmgpu-enable-transform-dialect-jit=false --iree-codegen-llvmcpu-use-transform-dialect=${CODEGEN_SPEC_FILE}"
     fi
     CODEGEN_FLAG="${CODEGEN_FLAG} ${TRANSFORM_REPRO_FLAG}"
   else
@@ -154,14 +154,14 @@ function iree-transform-compile() {
     if test ${CODEGEN_SPEC_FILE} == /dev/null; then
       CODEGEN_FLAG="--iree-codegen-llvmgpu-enable-transform-dialect-jit"
     else
-      CODEGEN_FLAG="--iree-codegen-llvmgpu-use-transform-dialect=${CODEGEN_SPEC_FILE}"
+      CODEGEN_FLAG="--iree-codegen-llvmgpu-enable-transform-dialect-jit=false --iree-codegen-llvmgpu-use-transform-dialect=${CODEGEN_SPEC_FILE}"
     fi
     CODEGEN_FLAG="${CODEGEN_FLAG} ${TRANSFORM_REPRO_FLAG}"
   elif test ${BACKEND} == "llvm-cpu"; then
     if test ${CODEGEN_SPEC_FILE} == /dev/null; then
       CODEGEN_FLAG="--iree-codegen-llvmcpu-enable-transform-dialect-jit"
     else
-      CODEGEN_FLAG="--iree-codegen-llvmcpu-use-transform-dialect=${CODEGEN_SPEC_FILE}"
+      CODEGEN_FLAG="--iree-codegen-llvmgpu-enable-transform-dialect-jit=false --iree-codegen-llvmcpu-use-transform-dialect=${CODEGEN_SPEC_FILE}"
     fi
     CODEGEN_FLAG="${CODEGEN_FLAG} ${TRANSFORM_REPRO_FLAG}"
   else


### PR DESCRIPTION
With iree now using by default the jit mode for CUDA workloads, the script would choke with the interpreter mode because both the jit mode and interpreter mode would be set for the compiler. More precisely, the compilation would fail with:
"error: option clash in transform dialect lowering config: the filename cannot be provided when the jit optio n is set"

To avoid this problem, always specify the jit mode. That way, we're not affected by whatever is the default jit mode in the compiler.