### PR TITLE
[cuDNN] Initialize cudnnHandle_t when instantiating CuDNN module state

### DIFF
--- a/openxla-nvgpu/CMakeLists.txt
+++ b/openxla-nvgpu/CMakeLists.txt
@@ -6,14 +6,18 @@
 
 cmake_minimum_required(VERSION 3.21...3.24)
 
+project(OPENXLA_NVGPU)
+
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
-project(OPENXLA_NVGPU)
+set(CMAKE_CXX_STANDARD 17)
 
 # TODO: Fix this once the project is slotted into place.
 if(NOT IREE_ROOT_DIR)
   set(IREE_ROOT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../iree")
 endif()
+
+set(IREE_CXX_STANDARD ${CMAKE_CXX_STANDARD})
 
 # Customize defaults.
 option(IREE_BUILD_COMPILER "Disable compiler for runtime-library build" ON)
@@ -24,22 +28,18 @@ option(IREE_TARGET_BACKEND_DEFAULTS "Disables target backend" OFF)
 option(IREE_TARGET_BACKEND_CUDA "Enables CUDA target backend" ON)
 option(IREE_COMPILER_BUILD_SHARED_LIBS "Enables shared libraries in the compiler by default" ON)
 
-# TODO: `llvm-cpu` compiler backend and `local-sync` HAL driver are enabled only
-# for running tests. Diable them once we'll use proper CUDA target and driver.
-option(IREE_HAL_DRIVER_LOCAL_SYNC "Enables the 'local-sync' runtime HAL driver" ON)
-option(IREE_TARGET_BACKEND_LLVM_CPU "Enables the 'llvm-cpu' target backend" ON)
-
 set(IREE_COMPILER_PLUGIN_PATHS "${CMAKE_CURRENT_SOURCE_DIR}" CACHE STRING "OpenXLA nvgpu plugins")
 add_subdirectory("${IREE_ROOT_DIR}" "iree_core")
+
+# Handle various global definitions that need to be set at the global
+# toolchain level.
+iree_setup_toolchain()
 
 #-------------------------------------------------------------------------------
 # OpenXLA NVGPU Runtime.
 #
 # Integration of NVIDIA libraries with IREE runtime via custom VM modules.
 #-------------------------------------------------------------------------------
-
-# TODO: Use same compiler flags for building runtime targets as the IREE core.
-set(IREE_CXX_STANDARD 17)
 
 add_subdirectory(runtime)
 add_subdirectory(tools)

--- a/openxla-nvgpu/runtime/src/openxla/runtime/nvgpu/CMakeLists.txt
+++ b/openxla-nvgpu/runtime/src/openxla/runtime/nvgpu/CMakeLists.txt
@@ -24,6 +24,31 @@ iree_cc_library(
     "cudnn_module.cpp"
   DEPS
     ::defs
+    ::dynamic_symbols
     iree::runtime
+  PUBLIC
+)
+
+iree_cc_library(
+  NAME
+    dynamic_symbols
+  HDRS
+    "dynamic_symbols.h"
+    "status_util.h"
+  TEXTUAL_HDRS
+    "dynamic_symbol_tables.h"
+  SRCS
+    "cudnn_headers.h"
+    "dynamic_symbols.c"
+    "status_util.c"
+  DEPS
+    ::defs
+    iree::base
+    iree::base::core_headers
+    iree::base::internal::dynamic_library
+    iree::base::tracing
+    # TODO: We rely on the fact that cuDNN headers are located in the same
+    # directory as CUDA headers. Fix this.
+    iree_cuda::headers
   PUBLIC
 )

--- a/openxla-nvgpu/runtime/src/openxla/runtime/nvgpu/cudnn_headers.h
+++ b/openxla-nvgpu/runtime/src/openxla/runtime/nvgpu/cudnn_headers.h
@@ -1,0 +1,12 @@
+// Copyright 2023 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef OPENXLA_RUNTIME_NVGPU_CUDNN_HEADERS_H_
+#define OPENXLA_RUNTIME_NVGPU_CUDNN_HEADERS_H_
+
+#include "cudnn.h"  // IWYU pragma: export
+
+#endif  // OPENXLA_RUNTIME_NVGPU_CUDNN_HEADERS_H_

--- a/openxla-nvgpu/runtime/src/openxla/runtime/nvgpu/cudnn_module.cpp
+++ b/openxla-nvgpu/runtime/src/openxla/runtime/nvgpu/cudnn_module.cpp
@@ -6,11 +6,17 @@
 
 #include "openxla/runtime/nvgpu/cudnn_module.h"
 
+#include <iree/base/status.h>
 #include <iree/base/status_cc.h>
+#include <iree/vm/ref_cc.h>
 
 #include <cstdio>
 
+#include "iree/hal/drivers/cuda/cuda_device.h"
+#include "iree/modules/hal/types.h"
 #include "iree/vm/native_module_cc.h"
+#include "openxla/runtime/nvgpu/dynamic_symbols.h"
+#include "openxla/runtime/nvgpu/status_util.h"
 
 namespace openxla::runtime::nvgpu {
 
@@ -23,11 +29,30 @@ using namespace iree;
 
 class CuDNNModuleState {
  public:
+  CuDNNModuleState(openxla_cudnn_dynamic_symbols_t syms, cudnnHandle_t handle);
+  ~CuDNNModuleState();
+
   Status Hello() {
     fprintf(stderr, "Hello from OpenXLA CuDNN Module!\n");
     return OkStatus();
   }
+
+ private:
+  openxla_cudnn_dynamic_symbols_t syms_;
+
+  // IREE custom module state must be thread-compatible, and access to the same
+  // state object will be synchronized by the caller, so we can safely access
+  // cuDNN handle without any additional synchronization.
+  cudnnHandle_t handle_;
 };
+
+CuDNNModuleState::CuDNNModuleState(openxla_cudnn_dynamic_symbols_t syms,
+                                   cudnnHandle_t handle)
+    : syms_(syms), handle_(handle) {}
+
+CuDNNModuleState::~CuDNNModuleState() {
+  CUDNN_STATUS_CHECK_OK(&syms_, cudnnDestroy(handle_));
+}
 
 static const vm::NativeFunction<CuDNNModuleState> kCuDNNModuleFunctions[] = {
     vm::MakeNativeFunction("hello", &CuDNNModuleState::Hello),
@@ -39,13 +64,47 @@ static const vm::NativeFunction<CuDNNModuleState> kCuDNNModuleFunctions[] = {
 
 class CuDNNModule final : public vm::NativeModule<CuDNNModuleState> {
  public:
-  using vm::NativeModule<CuDNNModuleState>::NativeModule;
+  CuDNNModule(iree_vm_instance_t* instance, iree_hal_device_t* device,
+              iree_allocator_t host_allocator);
 
   StatusOr<std::unique_ptr<CuDNNModuleState>> CreateState(
-      iree_allocator_t host_allocator) override {
-    return std::make_unique<CuDNNModuleState>();
-  }
+      iree_allocator_t host_allocator) override;
+
+ private:
+  static constexpr uint32_t kVersion = 0;
+
+  using NativeModule = vm::NativeModule<CuDNNModuleState>;
+
+  // Retain a reference to the HAL (CUDA) device to keep CUDA context wrapper
+  // alive for the duration of cuDNN module lifetime.
+  vm::ref<iree_hal_device_t> device_;
+
+  // Underlying CUDA device behind the `device_` instance.
+  iree_hal_cuda_context_wrapper_t* cuda_ctx_ = nullptr;
 };
+
+CuDNNModule::CuDNNModule(iree_vm_instance_t* instance,
+                         iree_hal_device_t* device,
+                         iree_allocator_t host_allocator)
+    : NativeModule("cudnn", CuDNNModule::kVersion, instance, host_allocator,
+                   {kCuDNNModuleFunctions}),
+      device_(vm::retain_ref(device)),
+      cuda_ctx_(iree_hal_cuda_device_context_wrapper(device)) {}
+
+StatusOr<std::unique_ptr<CuDNNModuleState>> CuDNNModule::CreateState(
+    iree_allocator_t host_allocator) {
+  // Load cuDNN library and resolve API symbols.
+  openxla_cudnn_dynamic_symbols_t syms;
+  iree_status_t status =
+      openxla_cudnn_dynamic_symbols_initialize(host_allocator, &syms);
+  if (!iree_status_is_ok(status)) return status;
+
+  // Create a cuDNN handle for the new state object.
+  cudnnHandle_t handle;
+  CUDNN_RETURN_IF_ERROR(&syms, cudnnCreate(&handle), "cudnnCreate");
+
+  return std::make_unique<CuDNNModuleState>(syms, handle);
+}
 
 }  // namespace openxla::runtime::nvgpu
 
@@ -59,9 +118,14 @@ extern "C" iree_status_t iree_custom_module_cudnn_create(
     iree_vm_instance_t* instance, iree_hal_device_t* device,
     iree_allocator_t host_allocator, iree_vm_module_t** out_module) {
   IREE_ASSERT_ARGUMENT(out_module);
-  auto module = std::make_unique<CuDNNModule>(
-      "cudnn", /*version=*/0, instance, host_allocator,
-      span<const vm::NativeFunction<CuDNNModuleState>>(kCuDNNModuleFunctions));
+
+  if (!iree_hal_is_cuda_device(device)) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "cuDNN module requires HAL CUDA device");
+  }
+
+  auto module = std::make_unique<CuDNNModule>(instance, device, host_allocator);
   *out_module = module.release()->interface();
+
   return iree_ok_status();
 }

--- a/openxla-nvgpu/runtime/src/openxla/runtime/nvgpu/cudnn_module.cpp
+++ b/openxla-nvgpu/runtime/src/openxla/runtime/nvgpu/cudnn_module.cpp
@@ -38,6 +38,9 @@ class CuDNNModuleState {
   }
 
  private:
+  CuDNNModuleState(const CuDNNModuleState&) = delete;
+  CuDNNModuleState& operator=(const CuDNNModuleState&) = delete;
+
   openxla_cudnn_dynamic_symbols_t syms_;
 
   // IREE custom module state must be thread-compatible, and access to the same
@@ -101,6 +104,9 @@ StatusOr<std::unique_ptr<CuDNNModuleState>> CuDNNModule::CreateState(
 
   // Create a cuDNN handle for the new state object.
   cudnnHandle_t handle;
+  // TODO: We must guarantee that `cuda_ctx_` is current when we create cuDNN
+  // handle. Currently we rely on implicit guarantee that module is loaded
+  // immediately after device is created, however it might not always be true?
   CUDNN_RETURN_IF_ERROR(&syms, cudnnCreate(&handle), "cudnnCreate");
 
   return std::make_unique<CuDNNModuleState>(syms, handle);

--- a/openxla-nvgpu/runtime/src/openxla/runtime/nvgpu/dynamic_symbol_tables.h
+++ b/openxla-nvgpu/runtime/src/openxla/runtime/nvgpu/dynamic_symbol_tables.h
@@ -1,0 +1,9 @@
+// Copyright 2023 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+CUDNN_PFN_DECL(cudnnCreate, cudnnHandle_t*)
+CUDNN_PFN_DECL(cudnnDestroy, cudnnHandle_t)
+CUDNN_PFN_DECL_STR_RETURN(cudnnGetErrorString)

--- a/openxla-nvgpu/runtime/src/openxla/runtime/nvgpu/dynamic_symbols.c
+++ b/openxla-nvgpu/runtime/src/openxla/runtime/nvgpu/dynamic_symbols.c
@@ -1,0 +1,76 @@
+// Copyright 2023 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "openxla/runtime/nvgpu/dynamic_symbols.h"
+
+#include <string.h>
+
+#include "iree/base/internal/dynamic_library.h"
+#include "iree/base/target_platform.h"
+#include "iree/base/tracing.h"
+
+static const char* kCuDNNLoaderSearchNames[] = {
+#if defined(IREE_PLATFORM_WINDOWS)
+    "nvcudnn.dll",
+#else
+    "libcudnn.so",
+#endif  // IREE_PLATFORM_WINDOWS
+};
+
+#define concat(A, B) A B
+
+// Load CUDA entry points, prefer _v2 version if it exists.
+static iree_status_t openxla_cudnn_dynamic_symbols_resolve_all(
+    openxla_cudnn_dynamic_symbols_t* syms) {
+#define CUDNN_PFN_DECL(cuDNNSymbolName, ...)                                  \
+  {                                                                           \
+    static const char* kName = #cuDNNSymbolName;                              \
+    IREE_RETURN_IF_ERROR(iree_dynamic_library_lookup_symbol(                  \
+        syms->cudnn_library, kName, (void**)&syms->cuDNNSymbolName));         \
+    static const char* kNameV2 = concat(#cuDNNSymbolName, "_v2");             \
+    void* funV2;                                                              \
+    iree_dynamic_library_lookup_symbol(syms->cudnn_library, kNameV2, &funV2); \
+    if (funV2) syms->cuDNNSymbolName = funV2;                                 \
+  }
+
+#include "openxla/runtime/nvgpu/dynamic_symbol_tables.h"  // IWYU pragma: export
+
+#undef CUDNN_PFN_DECL
+  return iree_ok_status();
+}
+
+iree_status_t openxla_cudnn_dynamic_symbols_initialize(
+    iree_allocator_t host_allocator,
+    openxla_cudnn_dynamic_symbols_t* out_syms) {
+  IREE_TRACE_ZONE_BEGIN(z0);
+  memset(out_syms, 0, sizeof(*out_syms));
+  iree_status_t status = iree_dynamic_library_load_from_files(
+      IREE_ARRAYSIZE(kCuDNNLoaderSearchNames), kCuDNNLoaderSearchNames,
+      IREE_DYNAMIC_LIBRARY_FLAG_NONE, host_allocator, &out_syms->cudnn_library);
+  if (iree_status_is_not_found(status)) {
+    iree_status_ignore(status);
+    IREE_TRACE_ZONE_END(z0);
+    return iree_make_status(IREE_STATUS_UNAVAILABLE,
+                            "cuDNN runtime library not available; ensure "
+                            "installed and on path");
+  }
+  if (iree_status_is_ok(status)) {
+    status = openxla_cudnn_dynamic_symbols_resolve_all(out_syms);
+  }
+  if (!iree_status_is_ok(status)) {
+    openxla_cudnn_dynamic_symbols_deinitialize(out_syms);
+  }
+  IREE_TRACE_ZONE_END(z0);
+  return status;
+}
+
+void openxla_cudnn_dynamic_symbols_deinitialize(
+    openxla_cudnn_dynamic_symbols_t* syms) {
+  IREE_TRACE_ZONE_BEGIN(z0);
+  iree_dynamic_library_release(syms->cudnn_library);
+  memset(syms, 0, sizeof(*syms));
+  IREE_TRACE_ZONE_END(z0);
+}

--- a/openxla-nvgpu/runtime/src/openxla/runtime/nvgpu/dynamic_symbols.c
+++ b/openxla-nvgpu/runtime/src/openxla/runtime/nvgpu/dynamic_symbols.c
@@ -14,7 +14,7 @@
 
 static const char* kCuDNNLoaderSearchNames[] = {
 #if defined(IREE_PLATFORM_WINDOWS)
-    "nvcudnn.dll",
+    "cudnn.dll",
 #else
     "libcudnn.so",
 #endif  // IREE_PLATFORM_WINDOWS
@@ -22,18 +22,13 @@ static const char* kCuDNNLoaderSearchNames[] = {
 
 #define concat(A, B) A B
 
-// Load CUDA entry points, prefer _v2 version if it exists.
 static iree_status_t openxla_cudnn_dynamic_symbols_resolve_all(
     openxla_cudnn_dynamic_symbols_t* syms) {
-#define CUDNN_PFN_DECL(cuDNNSymbolName, ...)                                  \
-  {                                                                           \
-    static const char* kName = #cuDNNSymbolName;                              \
-    IREE_RETURN_IF_ERROR(iree_dynamic_library_lookup_symbol(                  \
-        syms->cudnn_library, kName, (void**)&syms->cuDNNSymbolName));         \
-    static const char* kNameV2 = concat(#cuDNNSymbolName, "_v2");             \
-    void* funV2;                                                              \
-    iree_dynamic_library_lookup_symbol(syms->cudnn_library, kNameV2, &funV2); \
-    if (funV2) syms->cuDNNSymbolName = funV2;                                 \
+#define CUDNN_PFN_DECL(cuDNNSymbolName, ...)                          \
+  {                                                                   \
+    static const char* kName = #cuDNNSymbolName;                      \
+    IREE_RETURN_IF_ERROR(iree_dynamic_library_lookup_symbol(          \
+        syms->cudnn_library, kName, (void**)&syms->cuDNNSymbolName)); \
   }
 
 #include "openxla/runtime/nvgpu/dynamic_symbol_tables.h"  // IWYU pragma: export

--- a/openxla-nvgpu/runtime/src/openxla/runtime/nvgpu/dynamic_symbols.h
+++ b/openxla-nvgpu/runtime/src/openxla/runtime/nvgpu/dynamic_symbols.h
@@ -1,0 +1,52 @@
+// Copyright 2023 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef OPENXLA_RUNTIME_NVGPU_DYNAMIC_SYMBOLS_H_
+#define OPENXLA_RUNTIME_NVGPU_DYNAMIC_SYMBOLS_H_
+
+#include "iree/base/api.h"
+#include "iree/base/internal/dynamic_library.h"
+#include "openxla/runtime/nvgpu/cudnn_headers.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+// `openxla_cudnn_dynamic_symbols_t` allow loading dynamically a subset of cuDNN
+// API. It loads all the function declared in `dynamic_symbol_tables.h` and fail
+// if any of the symbol is not available. The functions signatures are matching
+// the declarations in `cudnn.h`. This mechanism is based on dynamic CUDA
+// symbols loading in the IREE HAL backend.
+typedef struct openxla_cudnn_dynamic_symbols_t {
+  iree_dynamic_library_t* cudnn_library;
+
+#define CUDNN_PFN_DECL(cuDNNSymbolName, ...) \
+  cudnnStatus_t (*cuDNNSymbolName)(__VA_ARGS__);
+#define CUDNN_PFN_DECL_STR_RETURN(cuDNNSymbolName, ...) \
+  const char* (*cuDNNSymbolName)(__VA_ARGS__);
+
+#include "openxla/runtime/nvgpu/dynamic_symbol_tables.h"  // IWYU pragma: export
+
+#undef CUDNN_PFN_DECL
+} openxla_cudnn_dynamic_symbols_t;
+
+// Initializes |out_syms| in-place with dynamically loaded cuDNN symbols.
+// openxla_cudnn_dynamic_symbols_deinitialize must be used to release the
+// library resources.
+iree_status_t openxla_cudnn_dynamic_symbols_initialize(
+    iree_allocator_t host_allocator, openxla_cudnn_dynamic_symbols_t* out_syms);
+
+// Deinitializes |syms| by unloading the backing library. All function pointers
+// will be invalidated. They _may_ still work if there are other reasons the
+// library remains loaded so be careful.
+void openxla_cudnn_dynamic_symbols_deinitialize(
+    openxla_cudnn_dynamic_symbols_t* syms);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // OPENXLA_RUNTIME_NVGPU_DYNAMIC_SYMBOLS_H_

--- a/openxla-nvgpu/runtime/src/openxla/runtime/nvgpu/status_util.c
+++ b/openxla-nvgpu/runtime/src/openxla/runtime/nvgpu/status_util.c
@@ -1,0 +1,24 @@
+// Copyright 2023 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "openxla/runtime/nvgpu/status_util.h"
+
+#include <stddef.h>
+
+#include "openxla/runtime/nvgpu/dynamic_symbols.h"
+
+iree_status_t openxla_cudnn_status_to_status(
+    openxla_cudnn_dynamic_symbols_t* syms, cudnnStatus_t status,
+    const char* file, uint32_t line) {
+  if (IREE_LIKELY(status == CUDNN_STATUS_SUCCESS)) {
+    return iree_ok_status();
+  }
+
+  const char* error_string = syms->cudnnGetErrorString(status);
+  return iree_make_status_with_location(file, line, IREE_STATUS_INTERNAL,
+                                        "cuDNN error '%s' (%d)", error_string,
+                                        status);
+}

--- a/openxla-nvgpu/runtime/src/openxla/runtime/nvgpu/status_util.h
+++ b/openxla-nvgpu/runtime/src/openxla/runtime/nvgpu/status_util.h
@@ -1,0 +1,54 @@
+// Copyright 2023 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef OPENXLA_RUNTIME_NVGPU_STATUS_UTIL_H_
+#define OPENXLA_RUNTIME_NVGPU_STATUS_UTIL_H_
+
+#include <stdint.h>
+
+#include "iree/base/api.h"
+#include "openxla/runtime/nvgpu/dynamic_symbols.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+// Converts a cudnnStatus_t to an iree_status_t.
+//
+// Usage:
+//   iree_status_t status = CUDNN_STATUS_TO_STATUS(cuDnnDoThing(...));
+#define CUDNN_STATUS_TO_STATUS(syms, expr, ...) \
+  openxla_cudnn_status_to_status((syms), ((syms)->expr), __FILE__, __LINE__)
+
+// IREE_RETURN_IF_ERROR but implicitly converts the cudnnStatus_t return value
+// to a iree_status_t.
+//
+// Usage:
+//   CUDNN_RETURN_IF_ERROR(cuDnnDoThing(...));
+#define CUDNN_RETURN_IF_ERROR(syms, expr, ...)                                \
+  IREE_RETURN_IF_ERROR(openxla_cudnn_status_to_status((syms), ((syms)->expr), \
+                                                      __FILE__, __LINE__),    \
+                       __VA_ARGS__)
+
+// IREE_CHECK_OK but implicitly converts the cudnnStatus_t return value to a
+// iree_status_t.
+//
+// Usage:
+//   CUDNN_STATUS_CHECK_OK(cuDnnDoThing(...));
+#define CUDNN_STATUS_CHECK_OK(syms, expr, ...)                         \
+  IREE_CHECK_OK(openxla_cudnn_status_to_status((syms), ((syms)->expr), \
+                                               __FILE__, __LINE__))
+
+// Converts a cudnnStatus_t to an iree_status_t.
+iree_status_t openxla_cudnn_status_to_status(
+    openxla_cudnn_dynamic_symbols_t* syms, cudnnStatus_t status,
+    const char* file, uint32_t line);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // OPENXLA_RUNTIME_NVGPU_STATUS_UTIL_H_

--- a/openxla-nvgpu/runtime/src/openxla/runtime/nvgpu/test/example.mlir
+++ b/openxla-nvgpu/runtime/src/openxla/runtime/nvgpu/test/example.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-compile %s --iree-hal-target-backends=llvm-cpu | openxla-runner - example.main | FileCheck %s
+// RUN: iree-compile %s --iree-hal-target-backends=cuda | openxla-runner - example.main | FileCheck %s
 
 module @example {
 

--- a/openxla-nvgpu/tools/openxla-runner.c
+++ b/openxla-nvgpu/tools/openxla-runner.c
@@ -38,10 +38,10 @@ int main(int argc, char** argv) {
   IREE_CHECK_OK(iree_runtime_instance_create(&instance_options, host_allocator,
                                              &instance));
 
-  // Try to create the device - it should always succeed as it's a CPU device.
+  // Try to create the CUDA device.
   iree_hal_device_t* device = NULL;
   IREE_CHECK_OK(iree_runtime_instance_try_create_default_device(
-      instance, iree_make_cstring_view("local-sync"), &device));
+      instance, iree_make_cstring_view("cuda"), &device));
 
   // Create one session per loaded module to hold the module state.
   iree_runtime_session_options_t session_options;


### PR DESCRIPTION
Depends on: https://github.com/openxla/iree/pull/12909

1. Use the same mechanism as IREE CUDA backend to resolve cuDNN symbols dynamically
2. Check that custom module HAL device is a CUDA device and create `cudnnHandle_t`

**TODO:** cuDNN library lookup is not a part of any of the build files, and currently cuDNN has to be installed locally, and added to `LD_LIBRARY_PATH`

```
build/iree_core/tools/iree-compile --iree-hal-target-backends=cuda runtime/src/openxla/runtime/nvgpu/test/example.mlir > /tmp/0

CUDNN_LOGDEST_DBG=stderr CUDNN_LOGINFO_DBG=1 LD_LIBRARY_PATH=/usr/local/cuda/lib64 build/tools/openxla-runner /tmp/0 example.main
```

Output:

```
I! CuDNN (v8801) function cudnnCreate() called:
i!     handle: location=host; addr=0x7fff36a07678;
i! Time: 2023-04-03T22:49:11.161086 (0d+0h+0m+0s since start)
i! Process=641540; Thread=641540; GPU=NULL; Handle=NULL; StreamId=NULL.

INVOKE BEGIN example.main
Hello from OpenXLA CuDNN Module!
INVOKE END example.main

I! CuDNN (v8801) function cudnnDestroy() called:
i! Time: 2023-04-03T22:49:11.678030 (0d+0h+0m+0s since start)
i! Process=641540; Thread=641540; GPU=NULL; Handle=NULL; StreamId=NULL.
```

/cc @chsigg, @frgossen
