### PR TITLE
Remove `tile_to_forall_and_workgroup_count_region` op occurencies.

### DIFF
--- a/transform_dialect/examples/cpu/conv_2d_nchw_fchw_codegen_spec.mlir
+++ b/transform_dialect/examples/cpu/conv_2d_nchw_fchw_codegen_spec.mlir
@@ -51,9 +51,11 @@ transform.sequence failures(propagate) {
   // Step 1. Tile to forall and sequential scf.for.
   // ======================================================
   %forall_l1, %conv_l1 =
-    transform.iree.tile_to_forall_and_workgroup_count_region %named_conv
+    transform.structured.tile_to_forall_op %named_conv
       num_threads [1]
       ( mapping = [#gpu.block<x>] )
+  transform.iree.populate_workgroup_count_region_using_num_threads_slice
+    %forall_l1 : (!pdl.operation) -> ()
 
   // Step 2. Tile to sequential scf.for. 
   // First level with some interchange and second level with sizes if 1 to 

--- a/transform_dialect/examples/cpu/conv_2d_nhwc_hwcf_codegen_spec.mlir
+++ b/transform_dialect/examples/cpu/conv_2d_nhwc_hwcf_codegen_spec.mlir
@@ -64,9 +64,11 @@ transform.sequence failures(propagate) {
   // Step 1. Tile to forall and sequential scf.for.
   // ======================================================
   %forall_l1, %conv_l1 =
-    transform.iree.tile_to_forall_and_workgroup_count_region %conv
+    transform.structured.tile_to_forall_op %conv
       tile_sizes [1]
       ( mapping = [#gpu.block<x>] )
+  transform.iree.populate_workgroup_count_region_using_num_threads_slice
+    %forall_l1 : (!pdl.operation) -> ()
 
   // Step 2. Tile to sequential scf.for.
   // ======================================================

--- a/transform_dialect/examples/cpu/matmul_step_01_lower.mlir
+++ b/transform_dialect/examples/cpu/matmul_step_01_lower.mlir
@@ -56,10 +56,12 @@ transform.sequence failures(propagate) {
   // IREE-specific connection to the runtime and threadpool, required to run e2e.
   // ============================================================================
   %forall, %matmul =
-    transform.iree.tile_to_forall_and_workgroup_count_region %original_matmul 
+    transform.structured.tile_to_forall_op %original_matmul
       num_threads [1]
       // TODO: IREE needs own workgroup mapping attribute independent of GPU.
       ( mapping = [#gpu.block<x>] )
+  transform.iree.populate_workgroup_count_region_using_num_threads_slice
+    %forall : (!pdl.operation) -> ()
   // Post-tiling canonicalizations, in particular to ensure num_threads == 1 in 
   // the IR and prepare for bufferization.
   transform.iree.apply_patterns %variant_op 

--- a/transform_dialect/examples/cpu/matmul_step_02_tile_and_vectorize.mlir
+++ b/transform_dialect/examples/cpu/matmul_step_02_tile_and_vectorize.mlir
@@ -89,10 +89,13 @@ transform.sequence failures(propagate) {
   // IREE-specific connection to the runtime and threadpool, required to run e2e.
   // ============================================================================
   %forall, %matmul =
-    transform.iree.tile_to_forall_and_workgroup_count_region %original_matmul 
+    transform.structured.tile_to_forall_op %original_matmul
       num_threads [1]
       // TODO: IREE needs own workgroup mapping attribute independent of GPU.
       ( mapping = [#gpu.block<x>] )
+  transform.iree.populate_workgroup_count_region_using_num_threads_slice
+    %forall : (!pdl.operation) -> ()
+
   // Post-tiling canonicalizations, in particular to ensure num_threads == 1 in 
   // the IR.
   transform.iree.apply_patterns %variant_op 

--- a/transform_dialect/examples/cpu/matmul_step_03_tile_and_vectorize_parallel.mlir
+++ b/transform_dialect/examples/cpu/matmul_step_03_tile_and_vectorize_parallel.mlir
@@ -95,10 +95,12 @@ transform.sequence failures(propagate) {
   // IREE-specific connection to the runtime and threadpool, required to run e2e.
   // ============================================================================
   %forall, %matmul =
-    transform.iree.tile_to_forall_and_workgroup_count_region %original_matmul 
+    transform.structured.tile_to_forall_op %original_matmul
       tile_sizes [64, 256]
       // TODO: IREE needs own workgroup mapping attribute independent of GPU.
       ( mapping = [#gpu.block<x>, #gpu.block<y>] )
+  transform.iree.populate_workgroup_count_region_using_num_threads_slice
+    %forall : (!pdl.operation) -> ()
 
   // Step 1. Tile to forall and sequential scf.for.
   // ======================================================

--- a/transform_dialect/examples/cpu/matmul_step_04_tile_and_vector_mask.mlir
+++ b/transform_dialect/examples/cpu/matmul_step_04_tile_and_vector_mask.mlir
@@ -50,9 +50,11 @@ transform.sequence failures(propagate) {
   // Step 1. Tile to forall and sequential scf.for.
   // ======================================================
   %forall_l1, %generic_l1 =
-    transform.iree.tile_to_forall_and_workgroup_count_region %generic
+    transform.structured.tile_to_forall_op %generic
       num_threads [1]
       ( mapping = [#gpu.block<x>] )
+  transform.iree.populate_workgroup_count_region_using_num_threads_slice
+    %forall_l1 : (!pdl.operation) -> ()
   transform.iree.apply_patterns %variant_op {canonicalization, cse, tiling_canonicalization}
     : (!pdl.operation) -> ()
  

--- a/transform_dialect/examples/cuda/copy_1d_codegen_spec.mlir
+++ b/transform_dialect/examples/cuda/copy_1d_codegen_spec.mlir
@@ -29,8 +29,10 @@ transform.sequence failures(propagate) {
     : (!pdl.operation) -> !pdl.operation
 
   %forall_l1, %copy_l1 =
-    transform.iree.tile_to_forall_and_workgroup_count_region %copy num_threads [2]
+    transform.structured.tile_to_forall_op %copy num_threads [2]
       ( mapping = [#gpu.block<x>] )
+  transform.iree.populate_workgroup_count_region_using_num_threads_slice
+    %forall_l1 : (!pdl.operation) -> ()
 
   // Late canonicalizations and cleanups.
   transform.iree.apply_patterns %variant_op

--- a/transform_dialect/examples/cuda/fill_matmul_unaligned_mma_sync_vector_4_codegen_spec.mlir
+++ b/transform_dialect/examples/cuda/fill_matmul_unaligned_mma_sync_vector_4_codegen_spec.mlir
@@ -74,8 +74,10 @@ transform.sequence failures(propagate) {
   // Step 1. Tile to forall and sequential scf.for.
   // ======================================================
   %forall_l1, %matmul_l1 =
-    transform.iree.tile_to_forall_and_workgroup_count_region %matmul tile_sizes [128, 128]
+    transform.structured.tile_to_forall_op %matmul tile_sizes [128, 128]
       ( mapping = [#gpu.block<y>, #gpu.block<x>] )
+  transform.iree.populate_workgroup_count_region_using_num_threads_slice
+    %forall_l1 : (!pdl.operation) -> ()
   %fill_l1 = transform.structured.fuse_into_containing_op %fill into %forall_l1
   %matmul_l2, %loops:1 = transform.structured.tile_to_scf_for %matmul_l1 [0, 0, 16]
  

--- a/transform_dialect/examples/cuda/fill_matmul_unaligned_wmma_vector_4_codegen_spec.mlir
+++ b/transform_dialect/examples/cuda/fill_matmul_unaligned_wmma_vector_4_codegen_spec.mlir
@@ -74,8 +74,10 @@ transform.sequence failures(propagate) {
   // Step 1. Tile to forall and sequential scf.for.
   // ======================================================
   %forall_l1, %matmul_l1 =
-    transform.iree.tile_to_forall_and_workgroup_count_region %matmul tile_sizes [128, 128]
+    transform.structured.tile_to_forall_op %matmul tile_sizes [128, 128]
       ( mapping = [#gpu.block<y>, #gpu.block<x>] )
+  transform.iree.populate_workgroup_count_region_using_num_threads_slice
+    %forall_l1 : (!pdl.operation) -> ()
   %fill_l1 = transform.structured.fuse_into_containing_op %fill into %forall_l1
   %matmul_l2, %loops:1 = transform.structured.tile_to_scf_for %matmul_l1 [0, 0, 16]
  

--- a/transform_dialect/examples/cuda/matmul_codegen_spec_step_02_pad_shared_wmma_async_pipelined_mapped.mlir
+++ b/transform_dialect/examples/cuda/matmul_codegen_spec_step_02_pad_shared_wmma_async_pipelined_mapped.mlir
@@ -169,8 +169,10 @@ transform.sequence failures(propagate) {
   // Step 1. Tile to forall and sequential scf.for.
   // ======================================================
   %forall_l1, %matmul_l1 =
-    transform.iree.tile_to_forall_and_workgroup_count_region %matmul tile_sizes [128, 128]
+    transform.structured.tile_to_forall_op %matmul tile_sizes [128, 128]
       ( mapping = [#gpu.block<y>, #gpu.block<x>] )
+  transform.iree.populate_workgroup_count_region_using_num_threads_slice
+    %forall_l1 : (!pdl.operation) -> ()
   %fill_l1 = transform.structured.fuse_into_containing_op %fill into %forall_l1
   %matmul_l2, %loops:1 = transform.structured.tile_to_scf_for %matmul_l1 [0, 0, 16]
   // // Post-tiling canonicalizations and cleanups.

--- a/transform_dialect/examples/cuda/matmul_dynamic_codegen_spec_pad_shared_wmma_async_pipelined_mapped.mlir
+++ b/transform_dialect/examples/cuda/matmul_dynamic_codegen_spec_pad_shared_wmma_async_pipelined_mapped.mlir
@@ -96,8 +96,10 @@ transform.sequence failures(propagate) {
   // Step 1. Tile to forall and sequential scf.for.
   // ======================================================
   %forall_l1, %matmul_l1 =
-    transform.iree.tile_to_forall_and_workgroup_count_region %matmul tile_sizes [128, 128]
+    transform.structured.tile_to_forall_op %matmul tile_sizes [128, 128]
       ( mapping = [#gpu.block<y>, #gpu.block<x>] )
+  transform.iree.populate_workgroup_count_region_using_num_threads_slice
+    %forall_l1 : (!pdl.operation) -> ()
   // %fill_l1 = transform.structured.fuse_into_containing_op %fill into %forall_l1
   %matmul_l2, %loops:1 = transform.structured.tile_to_scf_for %matmul_l1 [0, 0, 16]
   // Post-tiling canonicalizations and cleanups.

--- a/transform_dialect/examples/cuda/matmul_unaligned_codegen_spec_mma_sync.mlir
+++ b/transform_dialect/examples/cuda/matmul_unaligned_codegen_spec_mma_sync.mlir
@@ -76,8 +76,10 @@ transform.sequence failures(propagate) {
   // Step 1. Tile to forall and sequential scf.for.
   // ======================================================
   %forall_l1, %matmul_l1 =
-    transform.iree.tile_to_forall_and_workgroup_count_region %matmul tile_sizes [128, 128]
+    transform.structured.tile_to_forall_op %matmul tile_sizes [128, 128]
       ( mapping = [#gpu.block<y>, #gpu.block<x>] )
+  transform.iree.populate_workgroup_count_region_using_num_threads_slice
+    %forall_l1 : (!pdl.operation) -> ()
   // %fill_l1 = transform.structured.fuse_into_containing_op %fill into %forall_l1
   %matmul_l2, %loops:1 = transform.structured.tile_to_scf_for %matmul_l1 [0, 0, 16]
   // Post-tiling canonicalizations and cleanups.

--- a/transform_dialect/examples/cuda/matmul_unaligned_codegen_spec_step_02_pad_shared_wmma_async_pipelined_mapped_vector_1.mlir
+++ b/transform_dialect/examples/cuda/matmul_unaligned_codegen_spec_step_02_pad_shared_wmma_async_pipelined_mapped_vector_1.mlir
@@ -99,8 +99,10 @@ transform.sequence failures(propagate) {
   // Step 1. Tile to forall and sequential scf.for.
   // ======================================================
   %forall_l1, %matmul_l1 =
-    transform.iree.tile_to_forall_and_workgroup_count_region %matmul tile_sizes [128, 128]
+    transform.structured.tile_to_forall_op %matmul tile_sizes [128, 128]
       ( mapping = [#gpu.block<y>, #gpu.block<x>] )
+  transform.iree.populate_workgroup_count_region_using_num_threads_slice
+    %forall_l1 : (!pdl.operation) -> ()
   // %fill_l1 = transform.structured.fuse_into_containing_op %fill into %forall_l1
   %matmul_l2, %loops:1 = transform.structured.tile_to_scf_for %matmul_l1 [0, 0, 16]
   // Post-tiling canonicalizations and cleanups.

--- a/transform_dialect/examples/cuda/matmul_unaligned_codegen_spec_step_02_pad_shared_wmma_async_pipelined_mapped_vector_1_single_warp.mlir
+++ b/transform_dialect/examples/cuda/matmul_unaligned_codegen_spec_step_02_pad_shared_wmma_async_pipelined_mapped_vector_1_single_warp.mlir
@@ -101,8 +101,10 @@ transform.sequence failures(propagate) {
   // Step 1. Tile to forall and sequential scf.for.
   // ======================================================
   %forall_l1, %matmul_l1 =
-    transform.iree.tile_to_forall_and_workgroup_count_region %matmul tile_sizes [16, 16]
+    transform.structured.tile_to_forall_op %matmul tile_sizes [16, 16]
       ( mapping = [#gpu.block<y>, #gpu.block<x>] )
+  transform.iree.populate_workgroup_count_region_using_num_threads_slice
+    %forall_l1 : (!pdl.operation) -> ()
   // %fill_l1 = transform.structured.fuse_into_containing_op %fill into %forall_l1
   %matmul_l2, %loops:1 = transform.structured.tile_to_scf_for %matmul_l1 [0, 0, 8]
   // Post-tiling canonicalizations and cleanups.

--- a/transform_dialect/examples/cuda/matmul_unaligned_wmma_vector_4_codegen_spec.mlir
+++ b/transform_dialect/examples/cuda/matmul_unaligned_wmma_vector_4_codegen_spec.mlir
@@ -76,8 +76,10 @@ transform.sequence failures(propagate) {
   // Step 1. Tile to forall and sequential scf.for.
   // ======================================================
   %forall_l1, %matmul_l1 =
-    transform.iree.tile_to_forall_and_workgroup_count_region %matmul tile_sizes [128, 128]
+    transform.structured.tile_to_forall_op %matmul tile_sizes [128, 128]
       ( mapping = [#gpu.block<y>, #gpu.block<x>] )
+  transform.iree.populate_workgroup_count_region_using_num_threads_slice
+    %forall_l1 : (!pdl.operation) -> ()
   // %fill_l1 = transform.structured.fuse_into_containing_op %fill into %forall_l1
   %matmul_l2, %loops:1 = transform.structured.tile_to_scf_for %matmul_l1 [0, 0, 16]
   // Post-tiling canonicalizations and cleanups.

--- a/transform_dialect/examples/cuda/pointwise_iree_pipeline_spec.mlir
+++ b/transform_dialect/examples/cuda/pointwise_iree_pipeline_spec.mlir
@@ -29,8 +29,10 @@ transform.sequence failures(propagate) {
   // Step 1. Parallelize.
   // ====================
   %forall_l1, %generic_l1 =
-    transform.iree.tile_to_forall_and_workgroup_count_region %generic tile_sizes [128]
+    transform.structured.tile_to_forall_op %generic tile_sizes [128]
       ( mapping = [#gpu.block<x>] )
+  transform.iree.populate_workgroup_count_region_using_num_threads_slice
+    %forall_l1 : (!pdl.operation) -> ()
   transform.structured.tile_to_forall_op %generic_l1 num_threads [32]
       ( mapping = [#gpu.linear<x>] )
 

--- a/transform_dialect/examples/cuda/reduction_pipelined_spec.mlir
+++ b/transform_dialect/examples/cuda/reduction_pipelined_spec.mlir
@@ -66,8 +66,10 @@ transform.sequence failures(propagate) {
     : (!pdl.operation) -> !pdl.operation
 
   %forall_l1, %generic_l1 =
-    transform.iree.tile_to_forall_and_workgroup_count_region %generic tile_sizes [3]
+    transform.structured.tile_to_forall_op %generic tile_sizes [3]
       ( mapping = [#gpu.block<x>] )
+  transform.iree.populate_workgroup_count_region_using_num_threads_slice
+    %forall_l1 : (!pdl.operation) -> ()
   %generic_l2, %loops:1 = transform.structured.tile_to_scf_for %generic_l1 [0, 32]
 
   // Step 2. Pad, force packing abd hoist to create the buffer in shared memory.


### PR DESCRIPTION
We should use

```
%forall, %tiled_generic = transform.structured.tile_to_forall_op %0
  num_threads [2] ( mapping = [#gpu.block<x>] )
transform.iree.populate_workgroup_count_region_using_num_threads_slice
  %forall : (!pdl.operation) -> ()
```

instead.