### PR TITLE
Build the IREE runtime for Apple tvOS

### DIFF
--- a/runtime-library/CMakeLists.txt
+++ b/runtime-library/CMakeLists.txt
@@ -1,7 +1,8 @@
 # Copyright 2023 The IREE Authors
 #
-# Licensed under the Apache License v2.0 with LLVM Exceptions. See
-# https://llvm.org/LICENSE.txt for license information. SPDX-License-Identifier:
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 # Apache-2.0 WITH LLVM-exception
 
 cmake_minimum_required(VERSION 3.21...3.24)

--- a/runtime-library/CMakeLists.txt
+++ b/runtime-library/CMakeLists.txt
@@ -1,8 +1,8 @@
 # Copyright 2023 The IREE Authors
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions. See
-# https://llvm.org/LICENSE.txt for license information. SPDX-License-Identifier:
-# Apache-2.0 WITH LLVM-exception
+# https://llvm.org/LICENSE.txt for license
+# information. SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 cmake_minimum_required(VERSION 3.21...3.24)
 
@@ -46,9 +46,9 @@ endif()
 # development as it precludes important optimizations.
 option(BUILD_SHARED_LIBS "Build development shared runtime library" OFF)
 
-# When building a shared library, further customize: (1) Build with hidden
-# visibility by default. (2) Unhide API exported functions. (3) Mark symbols for
-# dllexport on Windows by default.
+# When building a shared library, further customize: (1) Build with
+# hidden visibility by default. (2) Unhide API exported functions. (3)
+# Mark symbols for dllexport on Windows by default.
 if(BUILD_SHARED_LIBS)
   message(
     STATUS

--- a/runtime-library/CMakeLists.txt
+++ b/runtime-library/CMakeLists.txt
@@ -1,8 +1,8 @@
 # Copyright 2023 The IREE Authors
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions. See
-# https://llvm.org/LICENSE.txt for license
-# information. SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+# https://llvm.org/LICENSE.txt for license information. SPDX-License-Identifier:
+# Apache-2.0 WITH LLVM-exception
 
 cmake_minimum_required(VERSION 3.21...3.24)
 
@@ -46,9 +46,9 @@ endif()
 # development as it precludes important optimizations.
 option(BUILD_SHARED_LIBS "Build development shared runtime library" OFF)
 
-# When building a shared library, further customize: (1) Build with
-# hidden visibility by default. (2) Unhide API exported functions. (3)
-# Mark symbols for dllexport on Windows by default.
+# When building a shared library, further customize: (1) Build with hidden
+# visibility by default. (2) Unhide API exported functions. (3) Mark symbols for
+# dllexport on Windows by default.
 if(BUILD_SHARED_LIBS)
   message(
     STATUS

--- a/runtime-library/CMakeLists.txt
+++ b/runtime-library/CMakeLists.txt
@@ -1,8 +1,8 @@
 # Copyright 2023 The IREE Authors
 #
-# Licensed under the Apache License v2.0 with LLVM Exceptions.
-# See https://llvm.org/LICENSE.txt for license information.
-# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+# Licensed under the Apache License v2.0 with LLVM Exceptions. See
+# https://llvm.org/LICENSE.txt for license information. SPDX-License-Identifier:
+# Apache-2.0 WITH LLVM-exception
 
 cmake_minimum_required(VERSION 3.21...3.24)
 

--- a/runtime-library/CMakeLists.txt
+++ b/runtime-library/CMakeLists.txt
@@ -3,7 +3,6 @@
 # Licensed under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-# Apache-2.0 WITH LLVM-exception
 
 cmake_minimum_required(VERSION 3.21...3.24)
 

--- a/runtime-library/create_xcframework.sh
+++ b/runtime-library/create_xcframework.sh
@@ -297,10 +297,22 @@ build_iree_for_host
 # build_iree_runtime_for_ios dev x86_64
 #
 # This step also merge dependent static libraries into the target library.
+build_iree_runtime_for_device tv-sim arm64
+build_iree_runtime_for_device tv-sim x86_64
+build_iree_runtime_for_device tv-dev arm64
+build_iree_runtime_for_device tv-dev arm64e
+
+# watchOS does not have thread_resume.
+# build_iree_runtime_for_device watch-sim arm64
+# build_iree_runtime_for_device watch-sim x86_64
+# build_iree_runtime_for_device watch-dev arm64
+# build_iree_runtime_for_device watch-dev arm64e
+
 build_iree_runtime_for_device ios-sim arm64
 build_iree_runtime_for_device ios-sim x86_64
 build_iree_runtime_for_device ios-dev arm64
 build_iree_runtime_for_device ios-dev arm64e
+
 build_iree_runtime_for_macos x86_64
 build_iree_runtime_for_macos arm64
 
@@ -323,5 +335,7 @@ xcodebuild -create-xcframework \
     -framework "$IREE_BUILD_RUNTIME_DIR"/macos-arm64/lib/iree.framework \
     -framework "$IREE_BUILD_RUNTIME_DIR"/ios-sim-arm64/lib/iree.framework \
     -framework "$IREE_BUILD_RUNTIME_DIR"/ios-dev-arm64/lib/iree.framework \
+    -framework "$IREE_BUILD_RUNTIME_DIR"/tv-sim-arm64/lib/iree.framework \
+    -framework "$IREE_BUILD_RUNTIME_DIR"/tv-dev-arm64/lib/iree.framework \
     -output "$IREE_BUILD_RUNTIME_XCFRAMEWORK"
 tree -L 1 -d "$IREE_BUILD_RUNTIME_XCFRAMEWORK"

--- a/runtime-library/create_xcframework.sh
+++ b/runtime-library/create_xcframework.sh
@@ -141,8 +141,9 @@ function merge_static_libraries() {
     (
         cd "$static_lib_dir"
         mv iree libiree.a
-        if libtool -static -o iree libiree.a libflatcc_parsing.a libclog.a libcpuinfo.a \
-            >"$build_dir"/merge_static_libraries.log 2>&1; then
+        libtool -static -o iree libiree.a libflatcc_parsing.a libclog.a libcpuinfo.a \
+		>"$build_dir"/merge_static_libraries.log 2>&1
+        if $?; then
             echo "Merged for $label successfully"
         fi
     )

--- a/runtime-library/create_xcframework.sh
+++ b/runtime-library/create_xcframework.sh
@@ -143,9 +143,7 @@ function merge_static_libraries() {
         mv iree libiree.a
         libtool -static -o iree libiree.a libflatcc_parsing.a libcpuinfo.a \
 		>"$build_dir"/merge_static_libraries.log 2>&1
-        if $?; then
-            echo "Merged for $label successfully"
-        fi
+        echo "Merged for $label successfully"
     )
 }
 

--- a/runtime-library/create_xcframework.sh
+++ b/runtime-library/create_xcframework.sh
@@ -141,7 +141,7 @@ function merge_static_libraries() {
     (
         cd "$static_lib_dir"
         mv iree libiree.a
-        libtool -static -o iree libiree.a libflatcc_parsing.a libclog.a libcpuinfo.a \
+        libtool -static -o iree libiree.a libflatcc_parsing.a libcpuinfo.a \
 		>"$build_dir"/merge_static_libraries.log 2>&1
         if $?; then
             echo "Merged for $label successfully"


### PR DESCRIPTION
- Enable build for tvOS
- Fix a bug that lipo failure does not crash the script
- Remove the linking to libclog.a, because it is no longer a dependency of pytorch/cpuinfo and will no longer be built.