### PR TITLE
Add first fp16 benchmarks

### DIFF
--- a/iree-torch/library/import_models.py
+++ b/iree-torch/library/import_models.py
@@ -4,39 +4,80 @@ import os
 import torch
 import torch_mlir
 
-from import_utils import import_torch_module_with_fx
+from import_utils import import_torch_module_with_fx, import_torch_module
 from models import bert_large, sd_clip_text_model, sd_unet_model, sd_vae_model, resnet50, t5_large, efficientnet_b7, efficientnet_v2_s
 
-_MODEL_NAME_TO_MODEL_CONFIG = {
+from dataclasses import dataclass
+from typing import Iterable, Dict
+
+@dataclass
+class ModelConfig:
+    model_class: torch.nn.Module
+    batch_sizes: Iterable[int]
+    dtype: torch.dtype = torch.float32
+    force_gpu: bool = False
+    import_with_fx: bool = True         # Determines use of import_torch_module_with_fx vs import_torch_module
+
+
+_MODEL_NAME_TO_MODEL_CONFIG: Dict[str, ModelConfig] = {
     # Batch sizes based on MLPerf config: https://github.com/mlcommons/inference_results_v2.1/tree/master/closed/NVIDIA/configs/bert
     "BERT_LARGE":
-    (bert_large.BertLarge, [1, 16, 24, 32, 48, 64, 512, 1024, 1280]),
-    "EFFICIENTNET_B7": (efficientnet_b7.EfficientNetB7, [
+    ModelConfig(bert_large.BertLarge, [1, 16, 24, 32, 48, 64, 512, 1024, 1280]),
+    "EFFICIENTNET_B7": ModelConfig(efficientnet_b7.EfficientNetB7, [
         1,
     ]),
-    "EFFICIENTNET_V2_S": (efficientnet_v2_s.EfficientNetV2S, [
+    "EFFICIENTNET_V2_S": ModelConfig(efficientnet_v2_s.EfficientNetV2S, [
         1,
     ]),
     # Batch sizes based on MLPerf config: https://github.com/mlcommons/inference_results_v2.1/tree/master/closed/NVIDIA/configs/resnet50
-    "RESNET50": (resnet50.Resnet50, [1, 8, 64, 128, 256, 2048]),
-    "SD_CLIP_TEXT_MODEL_SEQLEN64": (sd_clip_text_model.SDClipTextModel, [
+    "RESNET50": ModelConfig(resnet50.Resnet50, [1, 8, 64, 128, 256, 2048]),
+    "SD_CLIP_TEXT_MODEL_SEQLEN64": ModelConfig(sd_clip_text_model.SDClipTextModel, [
         1,
     ]),
-    "SD_VAE_MODEL": (sd_vae_model.SDVaeModel, [
+    "SD_VAE_MODEL": ModelConfig(sd_vae_model.SDVaeModel, [
         1,
     ]),
-    "SD_UNET_MODEL": (sd_unet_model.SDUnetModel, [
+    "SD_UNET_MODEL": ModelConfig(sd_unet_model.SDUnetModel, [
         1,
     ]),
-    "T5_LARGE": (t5_large.T5Large, [1,]),
+    "T5_LARGE": ModelConfig(t5_large.T5Large, [1,]),
+
+    # FP16 models below
+    "BERT_LARGE_FP16": ModelConfig(bert_large.BertLarge, 
+                                   [1, 16, 24, 32, 48, 64, 512, 1024, 1280], 
+                                   torch.float16, 
+                                   force_gpu=True),
+    "EFFICIENTNET_V2_S_FP16": ModelConfig(efficientnet_v2_s.EfficientNetV2S, [
+        1,
+    ], torch.float16, force_gpu=True, import_with_fx=False),
+    "RESNET50_FP16": ModelConfig(resnet50.Resnet50, 
+                                 [1, 8, 64, 128, 256, 2048], 
+                                 torch.float16, 
+                                 force_gpu=True, 
+                                 import_with_fx=False),
 }
 
 
-def import_to_mlir(model, batch_size):
-    inputs = model.generate_inputs(batch_size=batch_size)
-    mlir_data = import_torch_module_with_fx(
-        model, inputs, torch_mlir.OutputType.LINALG_ON_TENSORS)
-    return (inputs, mlir_data)
+def import_to_mlir(model_config: ModelConfig, batch_size: int):
+    model = model_config.model_class().to(dtype=model_config.dtype)
+    orig_inputs = model.generate_inputs(batch_size=batch_size, dtype=model_config.dtype)
+    converted_inputs = orig_inputs
+
+    if model_config.force_gpu:
+        model.cuda()
+        converted_inputs = [input.cuda() for input in orig_inputs]
+    
+    if model_config.import_with_fx:
+        mlir_data = import_torch_module_with_fx(
+            model, converted_inputs, torch_mlir.OutputType.LINALG_ON_TENSORS)
+    else:
+        graph = torch.jit.trace(model, converted_inputs)
+        mlir_data = import_torch_module(graph, converted_inputs, torch_mlir.OutputType.LINALG_ON_TENSORS)
+        
+        
+    outputs = model.forward(*converted_inputs)
+    outputs = outputs.cpu()
+    return (orig_inputs, outputs,  mlir_data)
 
 
 if __name__ == "__main__":
@@ -49,21 +90,21 @@ if __name__ == "__main__":
 
     for model_name, model_config in _MODEL_NAME_TO_MODEL_CONFIG.items():
         print(f"\n\n--- {model_name} -------------------------------------")
-        model_class = model_config[0]
-        batch_sizes = model_config[1]
+        if model_config.force_gpu and not torch.cuda.is_available():
+            print("SKIPPED due to missing CUDA installation")
+            continue
 
         model_dir = os.path.join(args.output_dir, model_name)
         os.makedirs(model_dir, exist_ok=True)
 
-        for batch_size in batch_sizes:
+        for batch_size in model_config.batch_sizes:
             save_dir = os.path.join(model_dir, f"batch_{batch_size}")
             os.makedirs(save_dir, exist_ok=True)
 
             try:
                 # Remove all gradient info from models and tensors since these models are inference only.
                 with torch.no_grad():
-                    model = model_class()
-                    inputs, mlir_data = import_to_mlir(model, batch_size)
+                    inputs, outputs, mlir_data = import_to_mlir(model_config, batch_size)
 
                     # Save inputs.
                     for idx, input in enumerate(inputs):
@@ -78,10 +119,9 @@ if __name__ == "__main__":
                         print(f"Saved {save_path}")
 
                     # Save output.
-                    outputs = model.forward(*inputs)
                     output_path = os.path.join(save_dir, f"output_0.npy")
                     print(f"Saving output 0 to {output_path}")
-                    np.save(output_path, outputs)
+                    np.save(output_path, outputs.cpu())
 
             except Exception as e:
                 print(f"Failed to import model {model_name}. Exception: {e}")

--- a/iree-torch/library/import_models.py
+++ b/iree-torch/library/import_models.py
@@ -3,6 +3,7 @@ import numpy as np
 import os
 import torch
 import torch_mlir
+import re
 
 from import_utils import import_torch_module_with_fx, import_torch_module
 from models import bert_large, sd_clip_text_model, sd_unet_model, sd_vae_model, resnet50, t5_large, efficientnet_b7, efficientnet_v2_s
@@ -86,9 +87,16 @@ if __name__ == "__main__":
                            "--output_dir",
                            default="/tmp",
                            help="Path to save mlir files")
+    argParser.add_argument("-f", 
+                           "--filter", 
+                           default=".*", 
+                           help="Regexp filter to match benchmark names")
     args = argParser.parse_args()
 
     for model_name, model_config in _MODEL_NAME_TO_MODEL_CONFIG.items():
+        if not re.match(args.filter, model_name, re.IGNORECASE):
+            continue
+        
         print(f"\n\n--- {model_name} -------------------------------------")
         if model_config.force_gpu and not torch.cuda.is_available():
             print("SKIPPED due to missing CUDA installation")

--- a/iree-torch/library/import_torch_models.sh
+++ b/iree-torch/library/import_torch_models.sh
@@ -24,4 +24,4 @@ mkdir ${OUTPUT_DIR}
 
 pip list > ${OUTPUT_DIR}/version_info.txt
 
-python import_models.py -o ${OUTPUT_DIR}
+python import_models.py -o ${OUTPUT_DIR} "$@"

--- a/iree-torch/library/import_torch_models.sh
+++ b/iree-torch/library/import_torch_models.sh
@@ -8,9 +8,13 @@
 #
 # Requires python-3.10 and above and python-venv.
 # Downloads and installs the latest `torch-mlir` and `torch` dev nightly.
+#
+# Note: Some models require CUDA. If no GPU is available, these models will be skipped.
 
 rm -rf torch-models.venv
-bash setup_venv.sh
+export WITH_CUDA=1
+./setup_venv.sh
+unset WITH_CUDA
 source torch-models.venv/bin/activate
 
 TORCH_MLIR_VERSION=$(pip show torch-mlir | grep Version | sed -e "s/^Version: \(.*\)$/\1/g")

--- a/iree-torch/library/models/bert_large.py
+++ b/iree-torch/library/models/bert_large.py
@@ -12,8 +12,8 @@ class BertLarge(torch.nn.Module):
         super().__init__()
         self.model = BertModel.from_pretrained("bert-large-uncased")
 
-    def generate_inputs(self, batch_size=1):
-        tokenizer = BertTokenizer.from_pretrained('bert-large-uncased')
+    def generate_inputs(self, batch_size=1, dtype=torch.float32):
+        tokenizer = BertTokenizer.from_pretrained('bert-large-uncased', torch_dtype=dtype)
         input_text = ["a photo of a cat"] * batch_size
         inputs = tokenizer(text=input_text,
                            padding="max_length",

--- a/iree-torch/library/models/efficientnet_b7.py
+++ b/iree-torch/library/models/efficientnet_b7.py
@@ -22,7 +22,9 @@ class EfficientNetB7(torch.nn.Module):
         self.preprocess = weights.transforms()
         self.train(False)
 
-    def generate_inputs(self, batch_size=1):
+    def generate_inputs(self, batch_size=1, dtype=torch.float32):
+        assert dtype == torch.float32, "Input generation only implemented for float32"
+
         image = imagenet_test_data.get_image_input()
         tensor = self.preprocess(image).unsqueeze(0)
         tensor = tensor.repeat(batch_size, 1, 1, 1)

--- a/iree-torch/library/models/efficientnet_v2_s.py
+++ b/iree-torch/library/models/efficientnet_v2_s.py
@@ -22,9 +22,9 @@ class EfficientNetV2S(torch.nn.Module):
         self.preprocess = weights.transforms()
         self.train(False)
 
-    def generate_inputs(self, batch_size=1):
+    def generate_inputs(self, batch_size=1, dtype=torch.float32):
         image = imagenet_test_data.get_image_input()
-        tensor = self.preprocess(image).unsqueeze(0)
+        tensor = self.preprocess(image).to(dtype=dtype).unsqueeze(0)
         tensor = tensor.repeat(batch_size, 1, 1, 1)
         return (tensor, )
 

--- a/iree-torch/library/models/resnet50.py
+++ b/iree-torch/library/models/resnet50.py
@@ -23,9 +23,9 @@ class Resnet50(torch.nn.Module):
         self.preprocess = weights.transforms()
         self.train(False)
 
-    def generate_inputs(self, batch_size=1):
+    def generate_inputs(self, batch_size=1, dtype=torch.float32):
         image = imagenet_test_data.get_image_input()
-        tensor = self.preprocess(image).unsqueeze(0)
+        tensor = self.preprocess(image).to(dtype=dtype).unsqueeze(0)
         tensor = tensor.repeat(batch_size, 1, 1, 1)
         return (tensor, )
 

--- a/iree-torch/library/models/sd_clip_text_model.py
+++ b/iree-torch/library/models/sd_clip_text_model.py
@@ -17,7 +17,9 @@ class SDClipTextModel(torch.nn.Module):
             subfolder="text_encoder",
         )
 
-    def generate_inputs(self, batch_size=1):
+    def generate_inputs(self, batch_size=1, dtype=torch.float32):
+        assert dtype == torch.float32, "Input generation only implemented for float32"
+
         tokenizer = AutoTokenizer.from_pretrained(
             "openai/clip-vit-base-patch32")
         input_text = ["a photo of a cat"] * batch_size

--- a/iree-torch/library/models/sd_unet_model.py
+++ b/iree-torch/library/models/sd_unet_model.py
@@ -17,7 +17,9 @@ class SDUnetModel(torch.nn.Module):
         )
         self.train(False)
 
-    def generate_inputs(self, batch_size=1):
+    def generate_inputs(self, batch_size=1, dtype=torch.float32):
+        assert dtype == torch.float32, "Input generation only implemented for float32"
+
         # Use `SDClipTextModel` to generate text embeddings.
         clip = sd_clip_text_model.SDClipTextModel()
         text_embedding = clip.forward(*clip.generate_inputs(

--- a/iree-torch/library/models/sd_vae_model.py
+++ b/iree-torch/library/models/sd_vae_model.py
@@ -26,7 +26,9 @@ class SDVaeModel(torch.nn.Module):
         self.model = AutoencoderKL.from_pretrained(
             "CompVis/stable-diffusion-v1-4", subfolder="vae")
 
-    def generate_inputs(self, batch_size=1):
+    def generate_inputs(self, batch_size=1, dtype=torch.float32):
+        assert dtype == torch.float32, "Input generation only implemented for float32"
+
         # We use VAE to encode an image and return this for input to the VAE decoder.
         image = imagenet_test_data.get_image_input().resize([512, 512])
         input = transforms.ToTensor()(image).unsqueeze(0)

--- a/iree-torch/library/models/t5_large.py
+++ b/iree-torch/library/models/t5_large.py
@@ -11,7 +11,9 @@ class T5Large(torch.nn.Module):
         super().__init__()
         self.model = T5Model.from_pretrained("t5-large", return_dict=True)
 
-    def generate_inputs(self, batch_size=1):
+    def generate_inputs(self, batch_size=1, dtype=torch.float32):
+        assert dtype == torch.float32, "Input generation only implemented for float32"
+
         tokenizer = AutoTokenizer.from_pretrained("t5-large")
         tokenization_kwargs = {
             "pad_to_multiple_of": _SEQUENCE_LENGTH,

--- a/iree-torch/library/setup_venv.sh
+++ b/iree-torch/library/setup_venv.sh
@@ -22,7 +22,18 @@ source "$VENV_DIR/bin/activate" || die "Could not activate venv"
 # reference to the python executable from the venv.
 python -m pip install --upgrade pip || die "Could not upgrade pip"
 python -m pip install --upgrade -r "$TD/requirements.txt"
-python -m pip install --pre torch-mlir torchvision accelerate -f https://llvm.github.io/torch-mlir/package-index/ -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
+
+if [ -z "$WITH_CUDA" ]
+then
+  echo "Installing torch-mlir and dependencies without cuda support; set WITH_CUDA to enable cuda support."
+  python -m pip install --pre torch-mlir torchvision -f https://llvm.github.io/torch-mlir/package-index/ -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
+else
+  echo "Installing torch-mlir and dependencies with cuda support"
+  python -m pip install --pre torch-mlir torchvision -f https://llvm.github.io/torch-mlir/package-index/ --index-url https://download.pytorch.org/whl/nightly/cu118
+fi
+
+# Install accelerate after torch-mlir and torch installation to automatically pick a compatible version
+python -m pip install accelerate
 
 echo "Activate venv with:"
 echo "  source $VENV_DIR/bin/activate"


### PR DESCRIPTION
This adds support to specify the data type when generating artifacts
for the benchmarking pipeline through PyTorch, and adds three benchmarks
that worked out of the box:

* ResNet50
* EfficientNet_V2
* BertLarge

Dumping FP16 HLO requires a machine with CUDA, as PyTorch needs to trace
the graph and is lacking support for most operations on CPU.

This required a bit of fiddling with torch-mlir and torch versions, as
the initial scripts pulled nightly torch installers without CUDA
enabled.

On machines without a GPU, the model import can still be executed as
before, and the import of models that require a GPU will be skipped.

For easier testing, I added a filtering functionality to import_models.py - if
desired, I can move this into a separate PR.