### PR TITLE
Revert to using TF 2.12.0

### DIFF
--- a/.github/workflows/benchmark_xla.yml
+++ b/.github/workflows/benchmark_xla.yml
@@ -23,7 +23,7 @@ jobs:
       - gpu
       - os-family=Linux
     env:
-      TENSORFLOW_VERSION: 2.13.0-rc0
+      TENSORFLOW_VERSION: 2.12.0
       BENCHMARK_OUTPUT_DIR: xla-results-dir
       BENCHMARK_RESULTS_JSON: tf-xla.json
       BENCHMARK_DEVICE: gpu
@@ -57,7 +57,7 @@ jobs:
       - machine-type=c2-standard-16
       - os-family=Linux
     env:
-      TENSORFLOW_VERSION: 2.13.0-rc0
+      TENSORFLOW_VERSION: 2.12.0
       BENCHMARK_OUTPUT_DIR: xla-results-dir
       BENCHMARK_RESULTS_JSON: tf-xla.json
       BENCHMARK_DEVICE: cpu

--- a/iree-tf/benchmark/benchmark_all.sh
+++ b/iree-tf/benchmark/benchmark_all.sh
@@ -59,6 +59,10 @@ else
     ITERATIONS=20
 fi
 
+# Compiler-level benchmarks compile and run an inference per iteration.
+# We keep this number low to reduce total benchmark time.
+HLO_ITERATIONS=3
+
 # Create json file and populate with global information.
 rm "${OUTPUT_PATH}"
 echo "{\"trigger\": { \"timestamp\": \"$(date +'%s')\" }, \"benchmarks\": []}" > "${OUTPUT_PATH}"
@@ -69,7 +73,7 @@ for benchmark_id in "${BENCHMARK_IDS[@]}"; do
     --device="${DEVICE}"
     --output_path="${OUTPUT_PATH}"
     --iterations="${ITERATIONS}"
-    --hlo_iterations="${ITERATIONS}"
+    --hlo_iterations="${HLO_ITERATIONS}"
   )
 
   if [ -z "${TF_RUN_HLO_MODULE_PATH}" ]; then


### PR DESCRIPTION
Version 2.13.0-rc0 is crashing after benchmarking the first model. It doesn't appear to be de-allocating GPU memory on shutdown.

Also reduced the number of HLO iterations since it `run_benchmark_module` is compiling the model at every iteration and the runtime latency has a small std deviation.