### PR TITLE
Print a list of valid IDs when an invalid ID is provided

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .vscode/
 __pycache__
 *.venv/
+.python-version
 
 # CMake artifacts
 build/

--- a/iree-jax/benchmark/benchmark_model.py
+++ b/iree-jax/benchmark/benchmark_model.py
@@ -25,7 +25,9 @@ import data_types, jax_model_definitions, unique_ids
 
 def benchmark_lookup(unique_id: str):
   if unique_id not in jax_model_definitions.JAX_MODELS_DICT:
-    raise ValueError(f"Id {unique_id} does not exist in model suite.")
+    id_list = '\n  '.join(jax_model_definitions.JAX_MODELS_DICT.keys())
+    raise ValueError(f"Id {unique_id} does not exist in model suite. Expected "
+                     f"one of:\n  {id_list}")
 
   model_definition = jax_model_definitions.JAX_MODELS_DICT[unique_id]
   if unique_id.startswith(unique_ids.MODEL_RESNET50_FP32_JAX):
@@ -203,5 +205,5 @@ if __name__ == "__main__":
           "framework_level": framework_metrics,
       }
   }
-  print(result)
+  print(json.dumps(result, indent=2))
   dump_result(args.output_path, result)

--- a/iree-tf/benchmark/benchmark_model.py
+++ b/iree-tf/benchmark/benchmark_model.py
@@ -31,7 +31,9 @@ _TF_GPU_DEVICE = "/GPU:0"
 
 def benchmark_lookup(unique_id: str):
   if unique_id not in tf_model_definitions.TF_MODELS_DICT:
-    raise ValueError(f"Id {unique_id} does not exist in model suite.")
+    id_list = '\n  '.join(tf_model_definitions.TF_MODELS_DICT.keys())
+    raise ValueError(f"Id {unique_id} does not exist in model suite. Expected "
+                     f"one of:\n  {id_list}")
 
   model_definition = tf_model_definitions.TF_MODELS_DICT[unique_id]
   if unique_id.startswith(unique_ids.MODEL_RESNET50_FP32_TF):
@@ -286,5 +288,5 @@ if __name__ == "__main__":
           "compiler_level": compiler_metrics,
       },
   }
-  print(result)
+  print(json.dumps(result, indent=2))
   dump_result(args.output_path, result)


### PR DESCRIPTION
This makes it easier to diagnose where the mismatch is arising. Also updates the stdout benchmark result printing to be more human-readable.