### PR TITLE
Update iree-tf and iree-jax to be compatible with python 3.8

### DIFF
--- a/iree-jax/benchmark/benchmark_model.py
+++ b/iree-jax/benchmark/benchmark_model.py
@@ -140,7 +140,7 @@ if __name__ == "__main__":
                          help="The path to `run_hlo_module`.")
   argParser.add_argument(
       "--run_in_process",
-      action=argparse.BooleanOptionalAction,
+      action="store_true",
       help=
       "Whether to run the benchmark under the same process. Set this to true when profiling a single workload"
   )

--- a/iree-tf/benchmark/benchmark_model.py
+++ b/iree-tf/benchmark/benchmark_model.py
@@ -209,7 +209,7 @@ if __name__ == "__main__":
       help="The number of iterations to run compiler-level benchmarks.")
   argParser.add_argument(
       "--run_in_process",
-      action=argparse.BooleanOptionalAction,
+      action="store_true",
       help="Whether to run the benchmark under the same process. Set this to true when profiling a single workload")
 
   args = argParser.parse_args()


### PR DESCRIPTION
This was tested by running both versions of `benchmark_all.sh` with `python 3.8.16`. This is necessary for benchmarking PAX models, which currently requires `python 3.8`.