### PR TITLE
Use `multihost_hlo_runner` for XLA:GPU compiler-level benchmarks

### DIFF
--- a/.github/workflows/run_comparative_benchmarks.yml
+++ b/.github/workflows/run_comparative_benchmarks.yml
@@ -16,6 +16,7 @@ on:
 
 jobs:
   benchmark_gpu:
+    timeout-minutes: 720
     runs-on:
       - self-hosted  # must come first
       - runner-group=presubmit
@@ -71,6 +72,7 @@ jobs:
 
   
   benchmark_cpu:
+    timeout-minutes: 360
     runs-on:
       - self-hosted  # must come first
       - runner-group=presubmit

--- a/xla-hlo/benchmark/benchmark_model.py
+++ b/xla-hlo/benchmark/benchmark_model.py
@@ -1,5 +1,6 @@
 import argparse
 import json
+import os
 import pathlib
 import re
 import requests
@@ -16,7 +17,10 @@ sys.path.insert(
         pathlib.Path(__file__).parent.parent.parent / "oobi" /
         "benchmark-definitions" / "python"))
 import data_types, jax_model_definitions, model_dictionary, tf_model_definitions, unique_ids
-from utils import execution_environment
+
+TIME_UNITS = {"us": 1e-3, "ms": 1, "s": 1e3, "min": 60 * 1e3, "h": 3600 * 1e3}
+TIME_REGEXP = re.compile(r"time: (\d+\.?\d*) (%s)" % "|".join(TIME_UNITS))
+SIZE_REGEXP = re.compile(r" (\d+) bytes")
 
 
 def benchmark_lookup(unique_id: str):
@@ -37,13 +41,124 @@ def dump_result(file_path: str, result: dict) -> None:
   with open(file_path, "w") as f:
     json.dump(dictObj, f)
 
-
 def bytes_to_mb(bytes: Optional[int]) -> Optional[float]:
   return None if bytes is None else bytes / 1e6
 
 
-def run_compiler_benchmark(hlo_benchmark_tool_path: str, hlo_input_path: str,
-                           benchmark_iterations: int, device: str) -> dict:
+def parse_log_time(line: bytes) -> float:
+  """Parses timestamp from the standard log.
+  """
+  match = re.search(rb"^(\d{4}-\d{2}-\d{2}) (\d{2}):(\d{2}):(\d{2}\.\d+):",
+                    line)
+  assert match, "Unable to parse log time: %s" % line
+  _, h, m, s = match.groups()
+  return 1000 * (int(h) * 3600 + int(m) * 60 + float(s))
+
+
+def parse_log_elapsed_time(line1: bytes, line2: bytes) -> float:
+  """Calculates elapsed time between two log lines.
+  """
+  start, end = parse_log_time(line1), parse_log_time(line2)
+  end += 86400 if end < start else 0  # next day correction
+  return end - start
+
+
+def parse_latencies(raw_output: bytes, expected_iterations: int) -> list[float]:
+  """Returns a list of latencies in milliseconds parsed from XLA logs.
+  """
+  start_regex = re.compile(rb".+HloRunner: ExecuteOnDevices started")
+  start_matches = re.findall(start_regex, raw_output)
+
+  stop_regex = re.compile(rb".+HloRunner: ExecuteOnDevices succeeded")
+  stop_matches = re.findall(stop_regex, raw_output)
+
+  assert len(start_matches) == len(
+      stop_matches) == expected_iterations, "Unable to parse output."
+  latencies = [
+      parse_log_elapsed_time(t1, t2)
+      for t1, t2 in zip(start_matches, stop_matches)
+  ]
+  return latencies
+
+
+def parse_log_duration(time_str: bytes) -> float:
+  """Returns the time in milliseconds parsed from XLA logs.
+  """
+  match = TIME_REGEXP.search(time_str.decode())
+  assert match, "Unable to parse the time on log line"
+  exp = TIME_UNITS[match.group(2)]
+  return float(match.group(1)) * exp
+
+
+def parse_log_size(size_str: bytes) -> float:
+  """Returns the size in bytes parsed from XLA logs.
+  """
+  match = SIZE_REGEXP.search(size_str.decode())
+  assert match, "Unable to parse the size on log line"
+  return float(match.group(1)) * 1e-6
+
+
+def parse_compile_time(raw_output: bytes,
+                       expected_iterations: int) -> list[float]:
+  compile_regex = re.compile(
+      rb"NVPTXCompiler::CompileTargetBinary - CompileToPtx.*")
+  matches = re.findall(compile_regex, raw_output)
+  total_compile_time_ms = sum([parse_log_duration(t1) for t1 in matches])
+  return total_compile_time_ms * 1e-3
+
+
+def parse_peak_memory(raw_output: bytes) -> float:
+  regex = re.compile(rb"New Peak memory usage of \d+ bytes for GPU")
+  matches = re.findall(regex, raw_output)
+  assert matches, "Unable to find peak memory"
+  return parse_log_size(matches[-1])
+
+
+def run_compiler_benchmark_gpu(hlo_benchmark_tool_path: str,
+                               hlo_input_path: str, benchmark_iterations: int,
+                               device: str) -> dict:
+  assert hlo_benchmark_tool_path.endswith("hlo_runner_main")
+
+  cmd = [
+      hlo_benchmark_tool_path,
+      f"--hlo_file={hlo_input_path}",
+      f"--device_type={device}",
+      f"--num_repeats={benchmark_iterations}",
+      "--input_format=text",
+      "--num_replicas=1",
+      "--num_partitions=1",
+      "--logtostderr",
+  ]
+
+  # Timings are logged under VLOG so we need to enable this.
+  os.environ["TF_CPP_MIN_VLOG_LEVEL"] = "0"
+  os.environ["TF_CPP_MAX_VLOG_LEVEL"] = "2"
+
+  result = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+  result_text = result.stdout
+
+  latencies = parse_latencies(result_text, benchmark_iterations)
+  compile_time_s = parse_compile_time(result_text, benchmark_iterations)
+  peak_memory_usage = parse_peak_memory(result_text)
+
+  results_dict = {
+      "compile_time_s": compile_time_s,
+      "min_latency_ms": min(latencies, default=None),
+      "max_latency_ms": max(latencies, default=None),
+      "mean_latency_ms": statistics.mean(latencies) if latencies else None,
+      "median_latency_ms": statistics.median(latencies) if latencies else None,
+      "stddev_latency_ms": statistics.stdev(latencies) if latencies else None,
+      "benchmark_iterations": benchmark_iterations,
+      "device_memory_peak_mb": peak_memory_usage,
+  }
+  return results_dict
+
+
+def run_compiler_benchmark_cpu(hlo_benchmark_tool_path: str,
+                               hlo_input_path: str, benchmark_iterations: int,
+                               device: str) -> dict:
+  assert hlo_benchmark_tool_path.endswith("run_hlo_module")
+
   cmd = [
       hlo_benchmark_tool_path,
       "--input_format=hlo",
@@ -82,16 +197,19 @@ def run_compiler_benchmark(hlo_benchmark_tool_path: str, hlo_input_path: str,
   return results_dict
 
 
+
 if __name__ == "__main__":
   argParser = argparse.ArgumentParser()
   argParser.add_argument(
       "-o",
       "--output_path",
+      required=True,
       help=
       "Path to results json file. Expects this file to have been pre-populated."
   )
   argParser.add_argument("-bid",
                          "--benchmark_id",
+                         required=True,
                          help="The unique id that defines a benchmark.")
   argParser.add_argument("-iter",
                          "--iterations",
@@ -104,8 +222,11 @@ if __name__ == "__main__":
       default="gpu",
       help="The device to run on. Currently `cpu` and `gpu` are supported.")
   argParser.add_argument("--hlo_benchmark_path",
-                         default=None,
+                         required=True,
                          help="The path to `run_hlo_module`.")
+  argParser.add_argument("--cache_dir",
+                         required=True,
+                         help="The path to save HLO artifacts")
 
   args = argParser.parse_args()
 
@@ -133,14 +254,29 @@ if __name__ == "__main__":
     hlo_artifact = model_definition.get_artifact(
         data_types.ModelArtifactType.TF_HLO_DUMP)
 
-  local_hlo_path = "/tmp/hlo_input.txt"
-  r = requests.get(hlo_artifact.source_url)
-  open(local_hlo_path, 'wb').write(r.content)
+  assert hlo_artifact.source_url.startswith("https://storage.googleapis.com/iree-model-artifacts/")
+  relative_path = hlo_artifact.source_url.removeprefix("https://storage.googleapis.com/iree-model-artifacts/")
+  hlo_local_path = os.path.join(args.cache_dir, relative_path)
+
+  if not os.path.exists(hlo_local_path):
+    pathlib.Path(os.path.dirname(hlo_local_path)).mkdir(parents=True, exist_ok=True)
+    r = requests.get(hlo_artifact.source_url)
+    print(f"Downloading {hlo_artifact.source_url}")
+    open(hlo_local_path, 'wb').write(r.content)
+  else:
+    print(f"{hlo_artifact.source_url} already downloaded.")
 
   # Retrieve compiler-level benchmarks.
-  compiler_metrics = run_compiler_benchmark(args.hlo_benchmark_path,
-                                            local_hlo_path, args.iterations,
-                                            args.device)
+  # We use different binaries for benchmarking gpu and cpu.
+  if args.device == "gpu":
+    compiler_metrics = run_compiler_benchmark_gpu(args.hlo_benchmark_path,
+                                                  hlo_local_path,
+                                                  args.iterations, args.device)
+  else:
+    compiler_metrics = run_compiler_benchmark_cpu(args.hlo_benchmark_path,
+                                                  hlo_local_path,
+                                                  args.iterations, args.device)
+
 
   result = {
       "definition": benchmark_definition,


### PR DESCRIPTION
Uses `xla/tools/multihost_hlo_runner:hlo_runner_main` instead of  `xla/tools:run_hlo_module` for XLA:GPU compiler-level benchmarks. This binary allows compiling once and running inference N times, and has more accurate compile-time and memory usage data.