### PR TITLE
Fix wrong profiling results.

### DIFF
--- a/iree-prof-tools/iree-prof-output-utils.cc
+++ b/iree-prof-tools/iree-prof-output-utils.cc
@@ -157,11 +157,6 @@ int64_t GetThreadDuration<tracy::GpuEvent>(const tracy::Worker& worker,
   return 0;
 }
 
-const char* GetZoneName(const tracy::Worker& worker,
-                        int16_t source_location_id) {
-  return worker.GetZoneName(worker.GetSourceLocation(source_location_id));
-}
-
 std::string GetSourceFileLine(const tracy::Worker& worker,
                               int16_t source_location_id) {
   const auto& zone = worker.GetSourceLocation(source_location_id);

--- a/iree-prof-tools/iree-prof-output-utils.h
+++ b/iree-prof-tools/iree-prof-output-utils.h
@@ -77,10 +77,6 @@ template <>
 int64_t GetThreadDuration<tracy::GpuEvent>(const tracy::Worker& worker,
                                            int thread_id);
 
-// Returns the zone name associated to a source location ID in a trace worker.
-const char* GetZoneName(const tracy::Worker& worker,
-                        int16_t source_location_id);
-
 // Gets source file:line string. May return an empty string if it is unknown.
 std::string GetSourceFileLine(const tracy::Worker& worker,
                               int16_t source_location_id);


### PR DESCRIPTION
Individual event name can be different from the zone name derived from source location.
Zone names must be retrieved from events.