### PR TITLE
[iree-prof-tools] Remove abseil-cpp submodule.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "third_party/abseil-cpp"]
-	path = third_party/abseil-cpp
-	url = https://github.com/abseil/abseil-cpp.git

--- a/iree-prof-tools/CMakeLists.txt
+++ b/iree-prof-tools/CMakeLists.txt
@@ -32,20 +32,33 @@ include(iree_cc_library)
 include(iree_install_support)
 include(external_cc_library)
 
-# Add third_party directories and libraries.
-set(ABSL_PROPAGATE_CXX_STD ON)
-add_subdirectory(${IREE_SAMPLES_ROOT_DIR}/third_party/abseil-cpp
-                 third_party/abseil-cpp EXCLUDE_FROM_ALL)
+# Add tracy in IREE repo.
 add_subdirectory(${IREE_ROOT_DIR}/build_tools/third_party/tracy
                  third_party/tracy EXCLUDE_FROM_ALL)
 
-include_directories(${IREE_SAMPLES_ROOT_DIR} ${IREE_ROOT_DIR})
+# Get abseil-cpp in ${CMAKE_BINARY_DIR}/third_party/abseil-cpp.
+set(ABSL_PROPAGATE_CXX_STD ON)
+include(FetchContent)
+FetchContent_Declare(
+  abseil-cpp
+  GIT_REPOSITORY https://github.com/abseil/abseil-cpp.git
+  GIT_TAG 20240116.0
+  SOURCE_DIR third_party/abseil-cpp
+  EXCLUDE_FROM_ALL
+)
+FetchContent_MakeAvailable(abseil-cpp)
+
+include_directories(
+  ${IREE_SAMPLES_ROOT_DIR} ${IREE_ROOT_DIR} ${CMAKE_BINARY_DIR}
+)
 
 # Set the default build type to Release if unspecified
 set(DEFAULT_CMAKE_BUILD_TYPE "Release")
 if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
-  message(STATUS "No build type selected, default to ${DEFAULT_CMAKE_BUILD_TYPE}")
-  set(CMAKE_BUILD_TYPE "${DEFAULT_CMAKE_BUILD_TYPE}" CACHE STRING "Build type (default ${DEFAULT_CMAKE_BUILD_TYPE})" FORCE)
+  message(STATUS
+          "No build type selected, default to ${DEFAULT_CMAKE_BUILD_TYPE}")
+  set(CMAKE_BUILD_TYPE "${DEFAULT_CMAKE_BUILD_TYPE}" CACHE STRING
+      "Build type (default ${DEFAULT_CMAKE_BUILD_TYPE})" FORCE)
 endif()
 
 #-------------------------------------------------------------------------------


### PR DESCRIPTION
Instead, download it into ${CMAKE_BINARY_DIR}/third_party/abseil-cpp through FetchContent.