### PR TITLE
[iree-prof-tools] Output per-op stats in stdout.

### DIFF
--- a/iree-prof-tools/iree-prof-output-stdout.h
+++ b/iree-prof-tools/iree-prof-output-stdout.h
@@ -7,6 +7,7 @@
 #ifndef IREE_PROF_OUTPUT_STDOUT_H_
 #define IREE_PROF_OUTPUT_STDOUT_H_
 
+#include <regex>
 #include <string>
 #include <vector>
 
@@ -25,8 +26,10 @@ class IreeProfOutputStdout : public IreeProfOutput {
     kSeconds,
   };
 
-  IreeProfOutputStdout(const std::vector<std::string>& zone_substrs,
-                       const std::vector<std::string>& thread_substrs,
+  IreeProfOutputStdout(bool output_zone_stats,
+                       bool output_per_op_stats,
+                       const std::string& zone_regex,
+                       const std::string& thread_regex,
                        DurationUnit unit);
   ~IreeProfOutputStdout() override;
 
@@ -37,8 +40,10 @@ class IreeProfOutputStdout : public IreeProfOutput {
   absl::Status Output(tracy::Worker& worker) override;
 
  private:
-  const std::vector<std::string> zone_substrs_;
-  const std::vector<std::string> thread_substrs_;
+  const bool output_zone_stats_;
+  const bool output_per_op_stats_;
+  const std::regex zone_regex_;
+  const std::regex thread_regex_;
   const DurationUnit unit_;
 };
 

--- a/iree-prof-tools/iree-prof-output.cc
+++ b/iree-prof-tools/iree-prof-output.cc
@@ -24,13 +24,15 @@ ABSL_FLAG(std::string, output_chrome_file, "",
           "or conversion.");
 ABSL_FLAG(bool, output_stdout, true,
           "Whether to print Tracy result to stdout.");
-ABSL_FLAG(std::vector<std::string>, zone_substrs,
-          std::vector<std::string>({"iree_hal_buffer_map_", "_dispatch_"}),
-          "Comma-separated substrings of tracy zones to output to stdout. "
-          "If empty, no zones will be output.");
-ABSL_FLAG(std::vector<std::string>, thread_substrs, {},
-          "Comma-separated substrings of threads to output to stdout. "
-          "If empty, all thread including main threads will be output.");
+ABSL_FLAG(bool, output_zones_stdout, true,
+          "Whether to print Tracy result of individual zones to stdout.");
+ABSL_FLAG(bool, output_ops_stdout, true,
+          "Whether to print Tracy result of ML operation to stdout.");
+ABSL_FLAG(std::string, zone_regex,
+          "iree_hal_buffer_map_(zero|fill|read|write|copy)|_dispatch_[0-9]+_",
+          "ECMAScript regex of tracy zones to output to stdout.");
+ABSL_FLAG(std::string, thread_regex, ".",
+          "ECMAScript regex of threads to output to stdout.");
 ABSL_FLAG(std::string, duration_unit, "milliseconds",
           "Unit of duration of zone to output to stdout. It must be one of "
           "seconds(s), millseconds(ms), microseconds(us), or nanoseconds(ns).");
@@ -65,8 +67,10 @@ IreeProfOutputStdout::DurationUnit ToUnit(const absl::string_view flag) {
 void Output(tracy::Worker& worker) {
   if (absl::GetFlag(FLAGS_output_stdout)) {
     LogStatusIfError(
-        IreeProfOutputStdout(absl::GetFlag(FLAGS_zone_substrs),
-                             absl::GetFlag(FLAGS_thread_substrs),
+        IreeProfOutputStdout(absl::GetFlag(FLAGS_output_zones_stdout),
+                             absl::GetFlag(FLAGS_output_ops_stdout),
+                             absl::GetFlag(FLAGS_zone_regex),
+                             absl::GetFlag(FLAGS_thread_regex),
                              ToUnit(absl::GetFlag(FLAGS_duration_unit)))
         .Output(worker));
   }


### PR DESCRIPTION
1) Use std::regex to extract ML operation names from zone names,
   e.g. "matmul" from "predict_dispatch_33_matmul_196x64x384_f32",
   "slow_memcpy" from "predict_dispatch_7_slow_memcpy",
   "pack" from "predict_dispatch_174_pack_f32"
2) Replace zone/thread_substrs command line flags with
   zone/thread_regex.