### PR TITLE
[iree-prof-tool] Initial implementation of iree compilation visualizer

### DIFF
--- a/iree-prof-tools/CMakeLists.txt
+++ b/iree-prof-tools/CMakeLists.txt
@@ -22,17 +22,30 @@ message("IREE-samples dir is ${IREE_SAMPLES_ROOT_DIR}")
 # this project.
 set(IREE_ROOT_DIR "${IREE_SAMPLES_ROOT_DIR}/../iree"
     CACHE STRING "Tell where is the local git-clone of IREE")
+set(IREE_BUILD_DIR "${IREE_ROOT_DIR}/../iree-build"
+    CACHE STRING "Tell where is the binary build directory of IREE")
 message("IREE dir is ${IREE_ROOT_DIR}")
+message("IREE build dir is ${IREE_BUILD_DIR}")
 
 # Load useful IREE CMake modules.
 list(APPEND CMAKE_MODULE_PATH ${IREE_ROOT_DIR}/build_tools/cmake/)
 include(iree_macros)
+include(iree_add_all_subdirs)
 include(iree_cc_binary)
 include(iree_cc_library)
 include(iree_install_support)
 include(external_cc_library)
 
-# Add tracy in IREE repo.
+# Add llvm and mlir in IREE repo.
+include(iree_llvm)
+iree_llvm_set_bundled_cmake_options()
+add_subdirectory(${IREE_ROOT_DIR}/third_party/llvm-project/llvm
+                 third_party/llvm-project/llvm EXCLUDE_FROM_ALL)
+add_library(IREELLVMIncludeSetup INTERFACE)
+
+# Add compiler and tracy in IREE repo.
+add_subdirectory(${IREE_ROOT_DIR}/compiler
+                 compiler EXCLUDE_FROM_ALL)
 add_subdirectory(${IREE_ROOT_DIR}/build_tools/third_party/tracy
                  third_party/tracy EXCLUDE_FROM_ALL)
 
@@ -50,6 +63,9 @@ FetchContent_MakeAvailable(abseil-cpp)
 
 include_directories(
   ${IREE_SAMPLES_ROOT_DIR} ${IREE_ROOT_DIR} ${CMAKE_BINARY_DIR}
+  ${IREE_ROOT_DIR}/third_party/llvm-project/llvm/include
+  ${IREE_ROOT_DIR}/third_party/llvm-project/mlir/include
+  ${IREE_BUILD_DIR}/llvm-project/tools/mlir/include
 )
 
 # Set the default build type to Release if unspecified
@@ -119,4 +135,21 @@ iree_cc_binary(
     absl::flags
     absl::log
     $<LINK_LIBRARY:WHOLE_ARCHIVE,absl::log_flags>
+)
+
+iree_cc_binary(
+  NAME
+    iree-vis
+  SRCS
+    "iree-vis.cc"
+  DEPS
+    absl::flags
+    absl::flags_parse
+    absl::log
+    absl::log_initialize
+    absl::log_severity
+    absl::strings
+    iree::compiler::bindings::c::headers
+    $<LINK_LIBRARY:WHOLE_ARCHIVE,absl::log_flags>
+    ${IREE_BUILD_DIR}/lib/libIREECompiler.so
 )

--- a/iree-prof-tools/iree-vis.cc
+++ b/iree-prof-tools/iree-vis.cc
@@ -1,0 +1,73 @@
+// Copyright 2024 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <string>
+
+#include "compiler/bindings/c/iree/compiler/embedding_api.h"
+#include "compiler/bindings/c/iree/compiler/mlir_interop.h"
+#include "third_party/abseil-cpp/absl/base/log_severity.h"
+#include "third_party/abseil-cpp/absl/log/globals.h"
+#include "third_party/abseil-cpp/absl/log/initialize.h"
+#include "third_party/abseil-cpp/absl/log/log.h"
+#include "third_party/abseil-cpp/absl/flags/flag.h"
+#include "third_party/abseil-cpp/absl/flags/parse.h"
+#include "third_party/abseil-cpp/absl/strings/str_cat.h"
+#include "third_party/llvm-project/mlir/include/mlir/IR/Operation.h"
+
+ABSL_FLAG(std::string, input_iree_file, "",
+          "IREE MLIR text assembly file to read.");
+ABSL_FLAG(std::string, iree_phase, "executable-sources",
+          "IREE compilation phase of input IREE MLIR file.");
+
+void Walk(mlir::Operation* op, absl::string_view indent) {
+  LOG(INFO) << indent << op->getName().getStringRef().str();
+  std::string child_indent = absl::StrCat(indent, "  ");
+  op->walk([op, indent = absl::string_view(child_indent)](
+      mlir::Operation* nested_op) {
+    if (nested_op != op) {
+      Walk(nested_op, indent);
+    }
+  });
+}
+
+int main(int argc, char** argv) {
+  absl::SetStderrThreshold(absl::LogSeverityAtLeast::kInfo);
+  absl::InitializeLog();
+  absl::ParseCommandLine(argc, argv);
+
+  ireeCompilerGlobalInitialize();
+  auto* session = ireeCompilerSessionCreate();
+
+  std::string input_iree_file = absl::GetFlag(FLAGS_input_iree_file);
+  iree_compiler_source_t* source;
+  auto* error =
+      ireeCompilerSourceOpenFile(session, input_iree_file.data(), &source);
+  if (error != nullptr) {
+    LOG(ERROR) << "Can't load input file, " << input_iree_file
+               << ": " << ireeCompilerErrorGetMessage(error);
+    ireeCompilerErrorDestroy(error);
+    ireeCompilerSessionDestroy(session);
+    ireeCompilerGlobalShutdown();
+    return 1;
+  }
+
+  auto* invoke = ireeCompilerInvocationCreate(session);
+  ireeCompilerInvocationSetCompileFromPhase(
+      invoke, absl::GetFlag(FLAGS_iree_phase).data());
+  if (ireeCompilerInvocationParseSource(invoke, source)) {
+    LOG(INFO) << "Parsing " << input_iree_file << " done successfully.";
+    auto op = ireeCompilerInvocationExportStealModule(invoke);
+    Walk(reinterpret_cast<mlir::Operation*>(op.ptr), "");
+    // Re-import op into the session to destroy it properly.
+    ireeCompilerInvocationImportStealModule(invoke, op);
+  }
+
+  ireeCompilerInvocationDestroy(invoke);
+  ireeCompilerSourceDestroy(source);
+  ireeCompilerSessionDestroy(session);
+  ireeCompilerGlobalShutdown();
+  return 0;
+}


### PR DESCRIPTION
1) iree-vis is a CLI to convert a iree mlir file to a json file for model explorer
2) This initial implementation simply prints operation names
3) It assumes libIREECompiler.so has been built from iree repo.