### PR TITLE
[iree-prof-tools] Revise iree-vis more.

### DIFF
--- a/iree-prof-tools/graph-util.cc
+++ b/iree-prof-tools/graph-util.cc
@@ -7,6 +7,7 @@
 #include "iree-prof-tools/graph-util.h"
 
 #include <string>
+#include <type_traits>
 
 #include "compiler/src/iree/compiler/Dialect/Stream/IR/StreamDialect.h"
 #include "compiler/src/iree/compiler/Dialect/Stream/IR/StreamOps.h"
@@ -23,6 +24,7 @@
 #include "third_party/llvm-project/llvm/include/llvm/Support/raw_os_ostream.h"
 #include "third_party/llvm-project/mlir/include/mlir/Dialect/Arith/IR/Arith.h"
 #include "third_party/llvm-project/mlir/include/mlir/Dialect/Func/IR/FuncOps.h"
+#include "third_party/llvm-project/mlir/include/mlir/IR/AsmState.h"
 #include "third_party/llvm-project/mlir/include/mlir/IR/BuiltinOps.h"
 #include "third_party/llvm-project/mlir/include/mlir/IR/Dialect.h"
 #include "third_party/llvm-project/mlir/include/mlir/IR/Operation.h"
@@ -32,33 +34,82 @@ namespace {
 
 using namespace mlir::iree_compiler;
 
-// A util template to return ASM-string of given T.
+// Printing flag to avoid unnecessary verifications in ToStr(). Verification
+// slows down the process due to thread synchronizations.
+mlir::OpPrintingFlags GetPrintingFlags() {
+  return mlir::OpPrintingFlags().assumeVerified().useLocalScope();
+}
+
+// Helper templates for ToStr() below.
+// Print() for non-mlir::Value types.
+template <typename T,
+          std::enable_if_t<!std::is_base_of_v<mlir::Value, T>, bool> = true>
+void Print(T v, llvm::raw_os_ostream& os) {
+  mlir::AsmState as(v.getContext(), GetPrintingFlags());
+  v.print(os, as);
+}
+
+// Print() for mlir::Value and its subclasses.
+template <typename T,
+          std::enable_if_t<std::is_base_of_v<mlir::Value, T>, bool> = true>
+void Print(T v, llvm::raw_os_ostream& os) {
+  v.printAsOperand(os, GetPrintingFlags());
+}
+
+// Print() for mlir::OperationName which doesn't have print() either with
+// AmsState or with OpPrintingFlags.
+template <>
+void Print<mlir::OperationName>(mlir::OperationName n,
+                                llvm::raw_os_ostream& os) {
+  n.print(os);
+}
+
+// A util templates to return ASM-string of given T.
 template <typename T>
 std::string ToStr(T v) {
   std::stringstream ss;
   llvm::raw_os_ostream os(ss);
-  v.print(os);
+  Print<T>(v, os);
   os.flush();
   return ss.str();
 }
 
-// Returns integer from a contant mlir value.
-int64_t ToInt(mlir::Value value) {
-  auto constant_op = llvm::cast<mlir::arith::ConstantOp>(value.getDefiningOp());
-  return llvm::cast<mlir::IntegerAttr>(constant_op.getValue()).getInt();
+std::string ToTypeStr(mlir::Type type, mlir::Value size) {
+  return absl::StrCat(ToStr(type), "{", ToStr(size), "}");
+}
+
+// Returns a graph KeyValuePair for a value which is either a constant value or
+// a variable.
+KeyValuePair ToKeyValuePair(absl::string_view key, mlir::Value val) {
+  if (auto op = llvm::dyn_cast<mlir::arith::ConstantOp>(val.getDefiningOp())) {
+    return KeyValuePair(key,
+                        llvm::cast<mlir::IntegerAttr>(op.getValue()).getInt());
+  }
+
+  return KeyValuePair(key, ToStr(val));
 }
 
 // Resource access flag of stream.cmd.dispatch op.
 enum DispatchResourceAccess {
   ACCESS_READ = 1,
   ACCESS_WRITE = 2,
-  ACCESS_READ_WRITE = 3,
+  ACCESS_READ_WRITE = ACCESS_READ|ACCESS_WRITE,
 };
 
 // Returns resource access flag of stream.cmd.dispatch op.
 DispatchResourceAccess ToAccess(mlir::Attribute attr) {
   return static_cast<DispatchResourceAccess>(
              llvm::cast<mlir::IntegerAttr>(attr).getInt());
+}
+
+// Builds a block argument id with |index|, |offset| and |length|.
+std::string GetArgId(int index,
+                     const KeyValuePair& offset,
+                     const KeyValuePair& length) {
+  return absl::StrCat("arg", index, "[", offset.value, ":",
+                      (offset.int_value && length.int_value
+                       ? absl::StrCat(*offset.int_value + *length.int_value)
+                       : absl::StrCat(offset.value, "+", length.value)), "]");
 }
 
 // Returns a string used as label for stream.cmd.dispatch op.
@@ -71,6 +122,19 @@ std::string GetLabel(IREE::Stream::CmdDispatchOp op) {
   return full_str;
 }
 
+// Returns a string used as label for stream.cmd.copy op.
+std::string GetLabel(IREE::Stream::CmdCopyOp op) {
+  auto source_arg = llvm::cast<mlir::BlockArgument>(op.getSource());
+  auto target_arg = llvm::cast<mlir::BlockArgument>(op.getTarget());
+  auto source_id = GetArgId(source_arg.getArgNumber(),
+                            ToKeyValuePair("offset", op.getSourceOffset()),
+                            ToKeyValuePair("length", op.getLength()));
+  auto target_id = GetArgId(target_arg.getArgNumber(),
+                            ToKeyValuePair("offset", op.getTargetOffset()),
+                            ToKeyValuePair("length", op.getLength()));
+  return absl::StrCat(ToStr(op->getName()), ":", source_id, "->", target_id);
+}
+
 // Returns a string used as label for stream.tensor.import op.
 std::string GetLabel(IREE::Stream::TensorImportOp op) {
   auto source = llvm::cast<mlir::BlockArgument>(op.getSource());
@@ -80,11 +144,6 @@ std::string GetLabel(IREE::Stream::TensorImportOp op) {
 // Returns a string used as label for util.global.load op.
 std::string GetLabel(IREE::Util::GlobalLoadOp op) {
   return absl::StrCat(ToStr(op->getName()), ":", op.getGlobal().str());
-}
-
-// Builds a resource id with |index|, |offset| and |size|.
-std::string GetResourceId(int index, int64_t offset, int64_t size) {
-  return absl::StrCat("resource-", index, "[", offset, ":", offset + size, "]");
 }
 
 // Whether an op is of function, i.e. func.func or util.func.
@@ -162,12 +221,14 @@ absl::StatusOr<mlir::Operation*> GetFuncWithName(mlir::ModuleOp module,
 // Adds a node with |label| and |parent_namespace| into |graph|.
 GraphNode& AddNode(absl::string_view label,
                    absl::string_view parent_namespace,
+                   absl::string_view op_name,
                    Graph& graph) {
   graph.nodes.push_back(std::make_unique<GraphNode>());
   auto& node = *graph.nodes.back();
   node.id = absl::StrCat(graph.nodes.size() - 1);
   node.label = label;
   node.node_namespace = parent_namespace;
+  node.node_attrs.emplace_back("op", op_name);
   return node;
 }
 
@@ -191,7 +252,7 @@ IncomingEdge* AddIncomingEdge(const GraphNode& source,
   input.source_node_output_id = source_node_output_id;
   int input_index = node.incoming_edges.size() - 1;
   input.target_node_input_id = absl::StrCat("input-", input_index);
-  input.metadata.emplace_back("index", input_index);
+  input.metadata.emplace_back("input_index", input_index);
   return &input;
 }
 
@@ -200,7 +261,8 @@ Metadata& AddOutputMetadata(GraphNode& node) {
   Metadata& output = node.outputs_metadata.emplace_back();
   int output_index = node.outputs_metadata.size() - 1;
   output.id = absl::StrCat("output-", output_index);
-  output.attrs.emplace_back("index", output_index);
+  output.attrs.emplace_back("node_id", node.id);
+  output.attrs.emplace_back("output_index", output_index);
   return output;
 }
 
@@ -211,7 +273,8 @@ GraphNode& AddNodeForOperation(
     const absl::flat_hash_map<mlir::Operation*, std::string>& op_namespaces,
     Graph& graph) {
   CHECK(op_namespaces.contains(op->getParentOp()));
-  return AddNode(label, op_namespaces.at(op->getParentOp()), graph);
+  return AddNode(label, op_namespaces.at(op->getParentOp()),
+                 ToStr(op->getName()), graph);
 }
 
 // Adds a node for |op| with a default label, i.e. op's name into |graph|.
@@ -222,13 +285,14 @@ GraphNode& AddNodeForOperation(
   return AddNodeForOperation(op, ToStr(op->getName()), op_namespaces, graph);
 }
 
-// Finds a node whose label is matched with |label_to_match|.
+// Finds a node whose label is matched with |label_to_match| in reverse order.
 // TODO(byungchul): Consider a map if this function is called many times.
 GraphNode* FindNodeForLabel(const Graph& graph,
-                            absl::string_view label_to_match) {
-  for (const auto& n : graph.nodes) {
-    if (label_to_match == n->label) {
-      return n.get();
+                            absl::string_view label_to_match,
+                            const GraphNode& node_to_skip) {
+  for (auto it = graph.nodes.rbegin(); it != graph.nodes.rend(); ++it) {
+    if (it->get() != &node_to_skip && (*it)->label == label_to_match) {
+      return it->get();
     }
   }
   return nullptr;
@@ -256,84 +320,94 @@ bool IsInConcurrent(const GraphNode& node) {
          node.node_namespace.npos;
 }
 
-// Whether two nodes are in a stream.cmd.concurrent op, i.e. last part of
-// namespace contains "stream.cmd.concurrent".
+// Whether two nodes are in a stream.cmd.concurrent op.
 bool IsInSameConcurrent(const GraphNode& a, const GraphNode& b) {
   return a.node_namespace == b.node_namespace && IsInConcurrent(a);
 }
 
-// Returns
-std::optional<int64_t> GetOutputIntAttr(const Metadata& output,
-                                        absl::string_view key) {
+// Returns an output metadata attribute matched with key.
+const KeyValuePair* GetOutputAttribute(const Metadata& output,
+                                       absl::string_view key) {
   for (const auto& a : output.attrs) {
     if (key == a.key) {
-      return a.int_value;
+      return &a;
     }
   }
-  return std::nullopt;
+  return nullptr;
 }
 
-// Whether an output is matched with |resource_id| or a tuple of |index|,
-// |offset|, and |size|.
-bool IsOutputMatched(const Metadata& output, absl::string_view resource_id,
-                     int index, int64_t offset, int64_t size) {
-  if (output.id == resource_id) {
+// Whether an output is matched with |arg_id| or a tuple of |index|, |offset|,
+// and |length|.
+bool IsOutputMatched(const Metadata& output,
+                     absl::string_view arg_id,
+                     int index,
+                     const KeyValuePair& offset,
+                     const KeyValuePair& length) {
+  if (output.id == arg_id) {
     return true;
   }
-  if (auto output_index = GetOutputIntAttr(output, "arg_index")) {
-    if (*output_index == index) {
-      // Output doesn't have to be matched with [offset:offset+size] exactly.
+  if (auto output_index = GetOutputAttribute(output, "arg_index")) {
+    if (output_index->int_value && *output_index->int_value == index) {
+      // Output doesn't have to be matched with [offset:offset+length] exactly.
       // As long as they are overlapped, it can be assumed the output is used
-      // as an input resource.
-      // Only if the end of either one is <= the start of the other, it is NOT
-      // overlapped. Note that start is inclusive while the end is not.
-      auto output_offset = GetOutputIntAttr(output, "offset");
-      auto output_size = GetOutputIntAttr(output, "size");
-      if (output_offset && output_size) {
-        auto end = offset + size;
-        auto output_end = *output_offset + *output_size;
-        CHECK_LE(offset, end);
-        CHECK_LE(*output_offset, output_end);
-        if (end <= *output_offset || offset >= output_end) {
-          return false;
+      // as an input resource. It is NOT overlapped only when the end of either
+      // one is <= the start of the other. Note that start is inclusive while
+      // the end is not.
+      auto output_offset = GetOutputAttribute(output, "offset");
+      if (output_offset) {
+        // Quick return when 2 offsets (either int value or arg name) are same.
+        if (offset.value == output_offset->value) {
+          return true;
         }
-        return true;
+        auto output_length = GetOutputAttribute(output, "length");
+        if (output_length && offset.int_value && length.int_value &&
+            output_offset->int_value && output_length->int_value) {
+          auto start = *offset.int_value;
+          auto end = start + *length.int_value;
+          CHECK_LE(start, end);
+          auto output_start = *output_offset->int_value;
+          auto output_end = output_start + *output_length->int_value;
+          CHECK_LE(output_start, output_end);
+          if (end <= output_start || start >= output_end) {
+            return false;
+          }
+          return true;
+        }
       }
     }
   }
   return false;
 }
 
-// Adds a |resource| of stream.cmd.dispatch |op| as an output or an incoming
-// edge of |node|.
-void AddResourceAsOutputOrIncomingEdge(IREE::Stream::CmdDispatchOp op,
-                                       int resource_index,
-                                       const Graph& graph,
-                                       GraphNode& node) {
-  auto resource =
-      llvm::cast<mlir::BlockArgument>(op.getResources()[resource_index]);
-  int index = resource.getArgNumber();
-  int64_t offset = ToInt(op.getResourceOffsets()[resource_index]);
-  int64_t size = ToInt(op.getResourceLengths()[resource_index]);
-  auto resource_id = GetResourceId(index, offset, size);
+// Adds a block argument as an output of |node|.
+void AddArgAsOutput(mlir::BlockArgument arg,
+                    mlir::Value arg_offset,
+                    mlir::Value arg_length,
+                    mlir::Value arg_size,
+                    GraphNode& node) {
+  auto offset = ToKeyValuePair("offset", arg_offset);
+  auto length = ToKeyValuePair("length", arg_length);
+  auto& output = AddOutputMetadata(node);
+  output.id = GetArgId(arg.getArgNumber(), offset, length);
+  output.attrs.emplace_back("arg_id", output.id);
+  output.attrs.emplace_back("arg_index", arg.getArgNumber());
+  output.attrs.emplace_back(std::move(offset));
+  output.attrs.emplace_back(std::move(length));
+  output.attrs.emplace_back("type", ToTypeStr(arg.getType(), arg_size));
+}
 
-  auto access = ToAccess(op.getResourceAccesses()[resource_index]);
-  if (access & ACCESS_WRITE) {
-    auto& output = AddOutputMetadata(node);
-    output.id = resource_id;
-    output.attrs.emplace_back("arg_index", index);
-    output.attrs.emplace_back("offset", offset);
-    output.attrs.emplace_back("size", size);
-    output.attrs.emplace_back("type", ToStr(resource.getType()));
-    if (!(access & ACCESS_READ)) {
-      return;
-    }
-  }
-
-  CHECK(access & ACCESS_READ);
+// Adds a block argument as an incoming edge of |node|.
+bool AddArgAsIncomingEdge(mlir::BlockArgument arg,
+                          mlir::Value arg_offset,
+                          mlir::Value arg_length,
+                          const Graph& graph,
+                          GraphNode& node) {
+  auto offset = ToKeyValuePair("offset", arg_offset);
+  auto length = ToKeyValuePair("length", arg_length);
+  auto arg_id = GetArgId(arg.getArgNumber(), offset, length);
 
   // First, find the last node(s) which is not in the same stream.cmd.concurrent
-  // and has an output matched with the resource. Note that they could be more
+  // and has an output matched with the argument. Note that they could be more
   // than one if last nodes are in a stream.cmd.concurrent (which is different
   // than that of this node).
   // TODO(byungchul): Consider the control flow, e.g. scf or cf ops. Uses in
@@ -345,11 +419,11 @@ void AddResourceAsOutputOrIncomingEdge(IREE::Stream::CmdDispatchOp op,
     }
     if (matched != nullptr && !IsInSameConcurrent(**it, *matched)) {
       // No more matched nodes in the same concurrent.
-      return;
+      return true;
     }
     for (int i = 0; i < (*it)->outputs_metadata.size(); ++i) {
-      if (IsOutputMatched((*it)->outputs_metadata[i], resource_id, index,
-                          offset, size)) {
+      if (IsOutputMatched((*it)->outputs_metadata[i], arg_id,
+                          arg.getArgNumber(), offset, length)) {
         matched = it->get();
         AddIncomingEdge(*matched, i, node);
         break;
@@ -357,10 +431,11 @@ void AddResourceAsOutputOrIncomingEdge(IREE::Stream::CmdDispatchOp op,
     }
   }
 
-  // Find a node from the original operand of this argument.
+  // If not found, find a node from the original operand of this argument.
   if (auto parent_op = llvm::dyn_cast<IREE::Stream::CmdExecuteOp>(
-          resource.getOwner()->getParentOp())) {
-    auto operand_op = parent_op.getResourceOperands()[index].getDefiningOp();
+          arg.getOwner()->getParentOp())) {
+    auto operand_op =
+        parent_op.getResourceOperands()[arg.getArgNumber()].getDefiningOp();
     std::string label_to_match;
     if (auto op = llvm::dyn_cast<IREE::Stream::TensorImportOp>(operand_op)) {
       label_to_match = GetLabel(op);
@@ -369,15 +444,15 @@ void AddResourceAsOutputOrIncomingEdge(IREE::Stream::CmdDispatchOp op,
     }
 
     if (!label_to_match.empty()) {
-      auto* matched = FindNodeForLabel(graph, label_to_match);
+      auto* matched = FindNodeForLabel(graph, label_to_match, node);
       if (matched) {
         AddIncomingEdge(*matched, 0, node);
-        return;
+        return true;
       }
     }
   }
 
-  LOG(WARNING) << "Can't find a matching output for resource: " << resource_id;
+  return false;
 }
 
 // Adds a node for a stream.cmd.dispatch op.
@@ -387,7 +462,27 @@ void AddNode(
     Graph& graph) {
   auto& node = AddNodeForOperation(op, GetLabel(op), op_namespaces, graph);
   for (int i = 0; i < op.getResources().size(); ++i) {
-    AddResourceAsOutputOrIncomingEdge(op, i, graph, node);
+    auto arg = llvm::cast<mlir::BlockArgument>(op.getResources()[i]);
+    auto access = ToAccess(op.getResourceAccesses()[i]);
+    CHECK(access & ACCESS_READ_WRITE);  // Read, write or both must be set.
+
+    if (access & ACCESS_WRITE) {
+      AddArgAsOutput(arg, op.getResourceOffsets()[i],
+                     op.getResourceLengths()[i], op.getResourceSizes()[i],
+                     node);
+    }
+
+    if (access & ACCESS_READ) {
+      if (!AddArgAsIncomingEdge(arg, op.getResourceOffsets()[i],
+                                op.getResourceLengths()[i], graph, node)) {
+        auto arg_id = GetArgId(
+            arg.getArgNumber(),
+            ToKeyValuePair("offset", op.getResourceOffsets()[i]),
+            ToKeyValuePair("length", op.getResourceLengths()[i]));
+        LOG(WARNING) << "Can't find a matching output: node=" << node.label
+                     << ", id=" << node.id << ", arg=" << arg_id;
+      }
+    }
   }
 }
 
@@ -397,18 +492,55 @@ void AddNode(
     const absl::flat_hash_map<mlir::Operation*, std::string>& op_namespaces,
     Graph& graph) {
   auto& node = AddNodeForOperation(op, op_namespaces, graph);
-  auto target = llvm::cast<mlir::BlockArgument>(op.getTarget());
-  int index = target.getArgNumber();
-  int64_t offset = ToInt(op.getTargetOffset());
-  int64_t size = ToInt(op.getTargetLength());
-  auto resource_id = GetResourceId(index, offset, size);
+  AddArgAsOutput(llvm::cast<mlir::BlockArgument>(op.getTarget()),
+                 op.getTargetOffset(), op.getTargetLength(), op.getTargetSize(),
+                 node);
+}
 
-  auto& output = AddOutputMetadata(node);
-  output.id = resource_id;
-  output.attrs.emplace_back("arg_index", index);
-  output.attrs.emplace_back("offset", offset);
-  output.attrs.emplace_back("size", size);
-  output.attrs.emplace_back("type", ToStr(op.getTarget().getType()));
+// Adds an incoming edge from an output matched with |type| and |size|.
+bool AddIncomingEdgeForType(mlir::Type type,
+                            mlir::Value size,
+                            const Graph& graph,
+                            GraphNode& node) {
+  auto type_to_match = ToTypeStr(type, size);
+  for (auto it = graph.nodes.rbegin(); it != graph.nodes.rend(); ++it) {
+    if (it->get() == &node || IsInSameConcurrent(**it, node)) {
+      continue;
+    }
+    for (int i = 0; i < (*it)->outputs_metadata.size(); ++i) {
+      if (auto* attr = GetOutputAttribute((*it)->outputs_metadata[i], "type")) {
+        if (attr->value == type_to_match) {
+          AddIncomingEdge(**it, i, node);
+          return true;
+        }
+      }
+    }
+  }
+  return false;
+}
+
+// Adds a node for a stream.cmd.copy op.
+void AddNode(
+    IREE::Stream::CmdCopyOp op,
+    const absl::flat_hash_map<mlir::Operation*, std::string>& op_namespaces,
+    Graph& graph) {
+  auto& node = AddNodeForOperation(op, GetLabel(op), op_namespaces, graph);
+  AddArgAsOutput(llvm::cast<mlir::BlockArgument>(op.getTarget()),
+                 op.getTargetOffset(), op.getLength(), op.getTargetSize(),
+                 node);
+
+  if (!AddArgAsIncomingEdge(llvm::cast<mlir::BlockArgument>(op.getSource()),
+                            op.getSourceOffset(), op.getLength(), graph, node)
+      && !AddIncomingEdgeForType(op.getSource().getType(), op.getSourceSize(),
+                                 graph, node)) {
+    auto source_id = GetArgId(
+        llvm::cast<mlir::BlockArgument>(op.getSource()).getArgNumber(),
+        ToKeyValuePair("offset", op.getSourceOffset()),
+        ToKeyValuePair("length", op.getLength()));
+    LOG(WARNING) << "Can't find a matching output: node=" << node.label
+                 << ", id=" << node.id << ", source=" << source_id << ", type="
+                 << ToTypeStr(op.getSource().getType(), op.getSourceSize());
+  }
 }
 
 // Adds a node for a stream.tensor.import op.
@@ -437,22 +569,12 @@ void AddNode(
 
   // Find a matching output with type for an incoming edge.
   // TODO(byungchul): Find matching output with source and index.
-  auto type_to_match = ToStr(op.getSource().getType());
-  for (auto it = graph.nodes.rbegin(); it != graph.nodes.rend(); ++it) {
-    if (it->get() == &node) {
-      continue;
-    }
-    for (int i = 0; i < (*it)->outputs_metadata.size(); ++i) {
-      for (const auto& a : (*it)->outputs_metadata[i].attrs) {
-        if (a.key == "type" && a.value == type_to_match) {
-          AddIncomingEdge(**it, i, node);
-          return;
-        }
-      }
-    }
+  if (!AddIncomingEdgeForType(op.getSource().getType(), op.getSourceSize(),
+                              graph, node)) {
+    LOG(WARNING) << "Can't find a matching output: node=" << node.label
+                 << ", type="
+                 << ToTypeStr(op.getSource().getType(), op.getSourceSize());
   }
-
-  LOG(WARNING) << "Can't find a matching output: " << type_to_match;
 }
 
 // Adds a node for a util.global.load op.
@@ -464,11 +586,48 @@ void AddNode(
   AddOutputMetadata(node);
 }
 
+// Append another namespace to group the operations if same operations continue
+// too many times in a row.
+// TODO(byungchul): Consider more groupings with compiler's help, or define
+// graph IR for easier conversions.
+void AppendNamespacesIfNecessary(const Graph& graph,
+                                 int min_num_ops_to_group) {
+  int index_of_first_same_op = 0;
+  int num_nodes_of_same_op = 0;
+  for (int i = 0; i < graph.nodes.size(); ++i) {
+    const auto& node = *graph.nodes[i];
+    CHECK_EQ(node.node_attrs[0].key, "op");
+    const auto& first = *graph.nodes[index_of_first_same_op];
+    const auto& op_name = first.node_attrs[0].value;
+    if (node.node_attrs[0].value == op_name &&
+        node.node_namespace == first.node_namespace) {
+      ++num_nodes_of_same_op;
+      continue;
+    }
+
+    // Append another namespace if there are too many same ops but they are NOT
+    // already grouped in a stream.cmd.concurrent.
+    if (num_nodes_of_same_op >= min_num_ops_to_group &&
+        !IsInConcurrent(first)) {
+      auto suffix = absl::StrCat("/", op_name, "-", first.id);
+      for (int i = 0; i < num_nodes_of_same_op; ++i) {
+        graph.nodes[index_of_first_same_op + i]->node_namespace.append(suffix);
+      }
+    }
+
+    num_nodes_of_same_op = 1;
+    index_of_first_same_op = i;
+  }
+}
+
 // Adds nodes accessed by |entrypoint| into |graph|.
-absl::Status AddNodesForEntrypoint(mlir::Operation* entrypoint, Graph& graph) {
+absl::Status AddNodesForEntrypoint(mlir::Operation* entrypoint,
+                                   int min_num_ops_to_group,
+                                   Graph& graph) {
   absl::flat_hash_map<mlir::Operation*, std::string> op_namespaces;
   op_namespaces[entrypoint] = GetFuncName(entrypoint);
 
+  absl::flat_hash_map<std::string, int> ops_ignored;
   entrypoint->walk<mlir::WalkOrder::PreOrder>([&](mlir::Operation* op) {
     if (llvm::isa<IREE::Stream::CmdExecuteOp>(op) ||
         llvm::isa<IREE::Stream::CmdConcurrentOp>(op)) {
@@ -477,23 +636,26 @@ absl::Status AddNodesForEntrypoint(mlir::Operation* entrypoint, Graph& graph) {
       AddNode(cop, op_namespaces, graph);
     } else if (auto cop = llvm::dyn_cast<IREE::Stream::CmdFillOp>(op)) {
       AddNode(cop, op_namespaces, graph);
+    } else if (auto cop = llvm::dyn_cast<IREE::Stream::CmdCopyOp>(op)) {
+      AddNode(cop, op_namespaces, graph);
     } else if (auto cop = llvm::dyn_cast<IREE::Stream::TensorImportOp>(op)) {
       AddNode(cop, op_namespaces, graph);
     } else if (auto cop = llvm::dyn_cast<IREE::Stream::TensorExportOp>(op)) {
       AddNode(cop, op_namespaces, graph);
     } else if (auto cop = llvm::dyn_cast<IREE::Util::GlobalLoadOp>(op)) {
       AddNode(cop, op_namespaces, graph);
-    } else if (llvm::isa<IREE::Stream::StreamDialect>(op->getDialect())) {
-      if (!llvm::isa<IREE::Stream::YieldOp>(op) &&
-          !llvm::isa<IREE::Stream::TimepointJoinOp>(op) &&
-          !llvm::isa<IREE::Stream::TimepointAwaitOp>(op) &&
-          !llvm::isa<IREE::Stream::ResourceAllocaOp>(op) &&
-          !llvm::isa<IREE::Stream::ResourceDeallocaOp>(op)) {
-        LOG(INFO) << "Ignore " << ToStr(op->getName());
-      }
+    } else {
+      ops_ignored[ToStr(op->getName())]++;
     }
   });
 
+  if (min_num_ops_to_group >= 0) {
+    AppendNamespacesIfNecessary(graph, min_num_ops_to_group);
+  }
+
+  for (const auto& it : ops_ignored) {
+    LOG(WARNING) << "Ignored " << it.second << " " << it.first << "(s).";
+  }
   return absl::OkStatus();
 }
 
@@ -502,7 +664,8 @@ absl::Status AddNodesForEntrypoint(mlir::Operation* entrypoint, Graph& graph) {
 absl::StatusOr<GraphCollection> GetGraphCollection(
     mlir::ModuleOp module,
     absl::string_view label,
-    absl::string_view entrypoint) {
+    absl::string_view entrypoint,
+    int min_num_ops_to_group) {
   auto func = entrypoint.empty() ? GetFuncWithMostStreams(module)
                                  : GetFuncWithName(module, entrypoint);
   if (!func.ok()) {
@@ -514,12 +677,12 @@ absl::StatusOr<GraphCollection> GetGraphCollection(
   Graph& graph = collection.graphs.emplace_back(GetFuncName(*func));
 
   // Add graph input/output nodes.
-  GraphNode& input_node = AddNode("GraphInput", "", graph);
+  GraphNode& input_node = AddNode("GraphInput", "", "graph-input", graph);
   AddOutputMetadata(input_node);
-  AddNode("GraphOutput", "", graph);
+  AddNode("GraphOutput", "", "graph-output", graph);
   // Graph outputs will be filled by entrypoint later.
 
-  auto status = AddNodesForEntrypoint(*func, graph);
+  auto status = AddNodesForEntrypoint(*func, min_num_ops_to_group, graph);
   if (!status.ok()) {
     return status;
   }

--- a/iree-prof-tools/graph-util.h
+++ b/iree-prof-tools/graph-util.h
@@ -19,7 +19,8 @@ namespace iree_prof::graph {
 absl::StatusOr<GraphCollection> GetGraphCollection(
     mlir::ModuleOp module,
     absl::string_view label,
-    absl::string_view entrypoint);
+    absl::string_view entrypoint,
+    int min_num_ops_to_group);
 
 }  // namespace iree_prof::graph
 

--- a/iree-prof-tools/graph.cc
+++ b/iree-prof-tools/graph.cc
@@ -12,7 +12,7 @@
 
 namespace iree_prof::graph {
 
-llvm::json::Object Attribute::Json() const {
+llvm::json::Object KeyValuePair::Json() const {
   llvm::json::Object json_attr;
   json_attr["key"] = key;
   json_attr["value"] = value;
@@ -24,8 +24,8 @@ llvm::json::Object Metadata::Json() const {
   json_metadata["id"] = id;
   json_metadata["attrs"] = llvm::json::Array();
   llvm::json::Array* json_attrs = json_metadata["attrs"].getAsArray();
-  for (const Attribute& attr : attrs) {
-    json_attrs->push_back(attr.Json());
+  for (const KeyValuePair& a : attrs) {
+    json_attrs->push_back(a.Json());
   }
   return json_metadata;
 }
@@ -37,8 +37,8 @@ llvm::json::Object IncomingEdge::Json() const {
   json_edge["targetNodeInputId"] = target_node_input_id;
   json_edge["metadata"] = llvm::json::Array();
   llvm::json::Array* json_attrs = json_edge["metadata"].getAsArray();
-  for (const Attribute& attr : metadata) {
-    json_attrs->push_back(attr.Json());
+  for (const KeyValuePair& m : metadata) {
+    json_attrs->push_back(m.Json());
   }
   return json_edge;
 }
@@ -52,8 +52,8 @@ llvm::json::Object GraphNode::Json() const {
 
   json_node["attrs"] = llvm::json::Array();
   llvm::json::Array* json_attrs = json_node["attrs"].getAsArray();
-  for (const Attribute& attr : node_attrs) {
-    json_attrs->push_back(attr.Json());
+  for (const KeyValuePair& a : node_attrs) {
+    json_attrs->push_back(a.Json());
   }
 
   json_node["incomingEdges"] = llvm::json::Array();

--- a/iree-prof-tools/graph.h
+++ b/iree-prof-tools/graph.h
@@ -12,17 +12,19 @@
 #include <string>
 
 #include "third_party/abseil-cpp/absl/strings/str_cat.h"
+#include "third_party/abseil-cpp/absl/strings/string_view.h"
 #include "third_party/llvm-project/llvm/include/llvm/Support/JSON.h"
 
 namespace iree_prof::graph {
 
 // An object with a pair of |key| and |value|.
-struct Attribute {
-  Attribute(std::string key, std::string value)
-      : key(std::move(key)), value(std::move(value)) {}
-  Attribute(std::string key, int64_t int_value)
-      : key(std::move(key)), value(absl::StrCat(int_value)),
-        int_value(int_value) {}
+struct KeyValuePair {
+  KeyValuePair(absl::string_view arg_key, absl::string_view arg_value)
+      : key(arg_key), value(arg_value) {}
+  KeyValuePair(absl::string_view arg_key, int64_t arg_int_value)
+      : key(arg_key),
+        value(absl::StrCat(arg_int_value)),
+        int_value(arg_int_value) {}
 
   std::string key;
   std::string value;
@@ -34,7 +36,7 @@ struct Attribute {
 // An item in output metadata of a node.
 struct Metadata {
   std::string id;
-  std::vector<Attribute> attrs;
+  std::vector<KeyValuePair> attrs;
 
   llvm::json::Object Json() const;
 };
@@ -49,7 +51,7 @@ struct IncomingEdge {
   // connects to.
   std::string target_node_input_id;
   // Other associated metadata for this edge.
-  std::vector<Attribute> metadata;
+  std::vector<KeyValuePair> metadata;
 
   llvm::json::Object Json() const;
 };
@@ -86,7 +88,7 @@ struct GraphNode {
   std::vector<std::string> subgraph_ids;
 
   // The attributes of the node.
-  std::vector<Attribute> node_attrs;
+  std::vector<KeyValuePair> node_attrs;
   // A list of incoming edges.
   std::vector<IncomingEdge> incoming_edges;
   // Metadata for outputs.


### PR DESCRIPTION
1) Group too many same ops in a sub-namespace.
2) Handle non-constants in argument offset and length.
3) Support stream.cmd.copy.
4) When to find a node with label, search it in reverse order to get the last one.
5) Add more metadata.
